### PR TITLE
remove dot which is invalid python argument character

### DIFF
--- a/ami/flowchart/Node.py
+++ b/ami/flowchart/Node.py
@@ -124,7 +124,7 @@ class Node(QtCore.QObject):
         name2 = name
         i = 1
         while name2 in self.terminals:
-            name2 = "%s.%d" % (name, i)
+            name2 = "%s%d" % (name, i)
             i += 1
         return name2
 


### PR DESCRIPTION
User was using In.1 and In.2 for terminal names which is invalid argument name