### PR TITLE
Roi and image shape / form factor

### DIFF
--- a/ami/client/flowchart.py
+++ b/ami/client/flowchart.py
@@ -24,6 +24,7 @@ from qtpy import QtCore, QtWidgets
 
 logger = logging.getLogger(LogConfig.get_package_name(__name__))
 
+pg.setConfigOption('imageAxisOrder', 'row-major')
 
 def run_editor_window(broker_addr, graphmgr_addr, checkpoint_addr, load=None, prometheus_dir=None,
                       prometheus_port=None, hutch=None, configure=False, save_dir=None):

--- a/ami/flowchart/library/DisplayWidgets.py
+++ b/ami/flowchart/library/DisplayWidgets.py
@@ -551,8 +551,8 @@ class ImageWidget(PlotWidget):
                       ('Label', 'text', {'group': 'Y Axis'}),
                       ('Log Scale', 'check', {'group': 'Y Axis', 'checked': False}),
                       # histogram
-                      ('Auto Range', 'check', {'group': 'Histogram', 'checked': True}),
-                      ('Auto Levels', 'check', {'group': 'Histogram', 'checked': True}),
+                      ('Auto Range', 'check', {'group': 'Histogram', 'checked': False}),
+                      ('Auto Levels', 'check', {'group': 'Histogram', 'checked': False}),
                       ('Log Scale', 'check', {'group': 'Histogram', 'checked': False})]
 
         display = kwargs.pop("display", True)
@@ -577,6 +577,7 @@ class ImageWidget(PlotWidget):
         self.imageItem = pg.ImageItem()
         self.imageItem.setZValue(-99)
         self.view.addItem(self.imageItem)
+        self.view.setAspectLocked(lock=self.lock, ratio=self.ratio)
 
         self.histogramLUT = pg.HistogramLUTItem(self.imageItem)
         self.histogramLUT.gradient.loadPreset('thermal')
@@ -605,7 +606,7 @@ class ImageWidget(PlotWidget):
             self.flip = self.plot_attrs['Display']['Flip']
             self.rotate = int(self.plot_attrs['Display']['Rotate Counter Clockwise'])/90
             self.lock = self.plot_attrs['Display']['Lock Aspect Ratio']
-
+        
         self.auto_levels = self.plot_attrs['Histogram']['Auto Levels']
         if not self.auto_levels:
             self.histogram_connected = True
@@ -623,6 +624,8 @@ class ImageWidget(PlotWidget):
             self.histogramLUT.autoHistogramRange()
         else:
             self.histogramLUT.vb.disableAutoRange()
+        
+        self.view.setAspectLocked(lock=self.lock, ratio=self.ratio)
 
     def data_updated(self, data):
         for k, v in data.items():
@@ -632,10 +635,9 @@ class ImageWidget(PlotWidget):
                 v = np.rot90(v, self.rotate)
             if self.log_scale_histogram:
                 v = np.log10(v)
-            self.view.setAspectLocked(lock=self.lock, ratio=self.ratio)
 
             if v.any():
-                self.imageItem.setImage(v.T, autoLevels=self.auto_levels)
+                self.imageItem.setImage(v, autoLevels=self.auto_levels)
 
     def saveState(self):
         state = super().saveState()

--- a/ami/flowchart/library/DisplayWidgets.py
+++ b/ami/flowchart/library/DisplayWidgets.py
@@ -604,7 +604,7 @@ class ImageWidget(PlotWidget):
 
         if 'Display' in self.plot_attrs:
             self.flip = self.plot_attrs['Display']['Flip']
-            self.rotate = int(self.plot_attrs['Display']['Rotate Counter Clockwise']) #/90
+            self.rotate = int(self.plot_attrs['Display']['Rotate Counter Clockwise']) / 90
             self.lock = self.plot_attrs['Display']['Lock Aspect Ratio']
         
         self.auto_levels = self.plot_attrs['Histogram']['Auto Levels']
@@ -634,8 +634,7 @@ class ImageWidget(PlotWidget):
             if self.log_scale_histogram:
                 v = np.log10(v)
             if self.rotate != 0:
-                self.imageItem.setTransformOriginPoint(self.imageItem.width()//2, self.imageItem.height()//2)
-                self.imageItem.setRotation(self.rotate)
+                v = np.rot90(v, self.rotate)
 
             if v.any():
                 self.imageItem.setImage(v, autoLevels=self.auto_levels)

--- a/ami/flowchart/library/DisplayWidgets.py
+++ b/ami/flowchart/library/DisplayWidgets.py
@@ -634,7 +634,6 @@ class ImageWidget(PlotWidget):
                 v = np.log10(v)
             self.view.setAspectLocked(lock=self.lock, ratio=self.ratio)
 
-
             if v.any():
                 self.imageItem.setImage(v.T, autoLevels=self.auto_levels)
 

--- a/ami/flowchart/library/DisplayWidgets.py
+++ b/ami/flowchart/library/DisplayWidgets.py
@@ -569,7 +569,7 @@ class ImageWidget(PlotWidget):
         self.rotate = 0
         self.log_scale_histogram = False
         self.auto_levels = False
-        self.ratio = 1 # need to see how to get the right aspect ratio from data
+        self.ratio = 1 # Update if we happen to have detectors that do not have square pixels
         self.lock = True
 
         self.view = self.plot_view.getViewBox()

--- a/ami/flowchart/library/DisplayWidgets.py
+++ b/ami/flowchart/library/DisplayWidgets.py
@@ -577,6 +577,7 @@ class ImageWidget(PlotWidget):
         self.imageItem = pg.ImageItem()
         self.imageItem.setZValue(-99)
         self.view.addItem(self.imageItem)
+        self.view.invertY()
         self.view.setAspectLocked(lock=self.lock, ratio=self.ratio)
 
         self.histogramLUT = pg.HistogramLUTItem(self.imageItem)
@@ -586,7 +587,6 @@ class ImageWidget(PlotWidget):
         if self.node:
             self.histogramLUT.sigLookupTableChanged.connect(
                 lambda args: self.node.sigStateChanged.emit(self.node))
-        
 
     def cursor_hover_evt(self, evt):
         pos = evt[0]
@@ -604,7 +604,7 @@ class ImageWidget(PlotWidget):
 
         if 'Display' in self.plot_attrs:
             self.flip = self.plot_attrs['Display']['Flip']
-            self.rotate = int(self.plot_attrs['Display']['Rotate Counter Clockwise'])/90
+            self.rotate = int(self.plot_attrs['Display']['Rotate Counter Clockwise']) #/90
             self.lock = self.plot_attrs['Display']['Lock Aspect Ratio']
         
         self.auto_levels = self.plot_attrs['Histogram']['Auto Levels']
@@ -631,10 +631,11 @@ class ImageWidget(PlotWidget):
         for k, v in data.items():
             if self.flip:
                 v = np.flip(v)
-            if self.rotate != 0:
-                v = np.rot90(v, self.rotate)
             if self.log_scale_histogram:
                 v = np.log10(v)
+            if self.rotate != 0:
+                self.imageItem.setTransformOriginPoint(self.imageItem.width()//2, self.imageItem.height()//2)
+                self.imageItem.setRotation(self.rotate)
 
             if v.any():
                 self.imageItem.setImage(v, autoLevels=self.auto_levels)

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -219,6 +219,11 @@ class Roi2D(CtrlNode):
                                     'Out': {'io': 'out', 'ttype': Array2d},
                                     'Roi_Coordinates': {'io': 'out', 'ttype': Array1d}},
                          viewable=True)
+        if self.widget:
+            self.rotation = self.widget.rotate
+        else:
+            self.rotation = 0
+        print(self.rotation) # it does not take the starting rotation.. How to fix that?
 
     def isChanged(self, restore_ctrl, restore_widget):
         return restore_ctrl
@@ -255,6 +260,8 @@ class Roi2D(CtrlNode):
         super().update(*args, **kwargs)
 
         if self.widget:
+            self.rotation = self.widget.rotate
+            print(self.rotation)
             self.roi.setPos(self.values['origin x'], y=self.values['origin y'], finish=False)
             self.roi.setSize((self.values['extent x'], self.values['extent y']), finish=False)
 
@@ -263,9 +270,16 @@ class Roi2D(CtrlNode):
         ex = self.values['extent x']
         oy = self.values['origin y']
         ey = self.values['extent y']
+        if hasattr(self, 'rotation'):
+            rotate = self.rotation
+        else:
+            rotate = 0
+        #breakpoint()
+        #print(rotate)
 
         def func(img):
-            return img[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
+            print(rotate)
+            return np.rot90(img, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -240,10 +240,10 @@ class Roi2D(CtrlNode):
         self.stateGroup.blockSignals(True)
         roi = args[0]
         extent, _, origin = roi.getAffineSliceParams(self.widget.imageItem.image, self.widget.imageItem)
-        self.values['origin x'] = int(origin[0])
-        self.values['origin y'] = int(origin[1])
-        self.values['extent x'] = int(extent[0])
-        self.values['extent y'] = int(extent[1])
+        self.values['origin x'] = int(origin[1])
+        self.values['origin y'] = int(origin[0])
+        self.values['extent x'] = int(extent[1])
+        self.values['extent y'] = int(extent[0])
         self.ctrls['origin x'].setValue(self.values['origin x'])
         self.ctrls['extent x'].setValue(self.values['extent x'])
         self.ctrls['origin y'].setValue(self.values['origin y'])
@@ -257,16 +257,16 @@ class Roi2D(CtrlNode):
         if self.widget:
             self.roi.setPos(self.values['origin x'], y=self.values['origin y'], finish=False)
             self.roi.setSize((self.values['extent x'], self.values['extent y']), finish=False)
+        
 
     def to_operation(self, **kwargs):
         ox = self.values['origin x']
         ex = self.values['extent x']
         oy = self.values['origin y']
         ey = self.values['extent y']
-        rotate = self.widget.rotate
 
         def func(img):
-            return np.rot90(img, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
+            return img[slice(oy, oy+ey), slice(ox, ox+ex)], (ox, ex, oy, ey)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -219,11 +219,6 @@ class Roi2D(CtrlNode):
                                     'Out': {'io': 'out', 'ttype': Array2d},
                                     'Roi_Coordinates': {'io': 'out', 'ttype': Array1d}},
                          viewable=True)
-        if self.widget:
-            self.rotation = self.widget.rotate
-        else:
-            self.rotation = 0
-        print(self.rotation) # it does not take the starting rotation.. How to fix that?
 
     def isChanged(self, restore_ctrl, restore_widget):
         return restore_ctrl
@@ -236,8 +231,6 @@ class Roi2D(CtrlNode):
                                   [self.values['extent x'], self.values['extent y']])
             self.roi.sigRegionChangeFinished.connect(self.set_values)
             self.widget.view.addItem(self.roi)
-
-        #from ami import forkedpdb; forkedpdb.ForkedPdb().set_trace()
 
         return self.widget
 
@@ -262,7 +255,6 @@ class Roi2D(CtrlNode):
         super().update(*args, **kwargs)
 
         if self.widget:
-            self.rotation = self.widget.rotate
             self.roi.setPos(self.values['origin x'], y=self.values['origin y'], finish=False)
             self.roi.setSize((self.values['extent x'], self.values['extent y']), finish=False)
 
@@ -271,18 +263,10 @@ class Roi2D(CtrlNode):
         ex = self.values['extent x']
         oy = self.values['origin y']
         ey = self.values['extent y']
-        if hasattr(self, 'rotation'):
-            rotate = self.rotation
-        else:
-            rotate = 0
-
-        roi = self.roi
-        image_item = self.widget.imageItem
+        rotate = self.widget.rotate
 
         def func(img):
-            #print(rotate)
-            return np.rot90(img.T, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
-            #return roi.getArrayRegion(image_item.image, image_item)
+            return np.rot90(img.T, -rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -251,6 +251,7 @@ class Roi2D(CtrlNode):
         self.stateGroup.blockSignals(False)
         self.sigStateChanged.emit(self)
 
+
     def update(self, *args, **kwargs):
         super().update(*args, **kwargs)
 
@@ -264,9 +265,13 @@ class Roi2D(CtrlNode):
         ex = self.values['extent x']
         oy = self.values['origin y']
         ey = self.values['extent y']
+        if self.widget is not None:
+            rotation = self.widget.rotate
+        else:
+            rotation = 0
 
-        def func(img):
-            return img[slice(oy, oy+ey), slice(ox, ox+ex)], (ox, ex, oy, ey)
+        def func(img): 
+            return np.rot90(img, rotation)[slice(oy, oy+ey), slice(ox, ox+ex)], (ox, ex, oy, ey)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -237,6 +237,8 @@ class Roi2D(CtrlNode):
             self.roi.sigRegionChangeFinished.connect(self.set_values)
             self.widget.view.addItem(self.roi)
 
+        #from ami import forkedpdb; forkedpdb.ForkedPdb().set_trace()
+
         return self.widget
 
     def set_values(self, *args, **kwargs):
@@ -261,7 +263,6 @@ class Roi2D(CtrlNode):
 
         if self.widget:
             self.rotation = self.widget.rotate
-            print(self.rotation)
             self.roi.setPos(self.values['origin x'], y=self.values['origin y'], finish=False)
             self.roi.setSize((self.values['extent x'], self.values['extent y']), finish=False)
 
@@ -274,11 +275,14 @@ class Roi2D(CtrlNode):
             rotate = self.rotation
         else:
             rotate = 0
-        #breakpoint()
+
+        roi = self.roi
+        image_item = self.widget.imageItem
 
         def func(img):
             #print(rotate)
             return np.rot90(img.T, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
+            #return roi.getArrayRegion(image_item.image, image_item)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -275,11 +275,10 @@ class Roi2D(CtrlNode):
         else:
             rotate = 0
         #breakpoint()
-        #print(rotate)
 
         def func(img):
-            print(rotate)
-            return np.rot90(img, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
+            #print(rotate)
+            return np.rot90(img.T, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 

--- a/ami/flowchart/library/Roi.py
+++ b/ami/flowchart/library/Roi.py
@@ -266,7 +266,7 @@ class Roi2D(CtrlNode):
         rotate = self.widget.rotate
 
         def func(img):
-            return np.rot90(img.T, -rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
+            return np.rot90(img, rotate)[slice(ox, ox+ex), slice(oy, oy+ey)], (ox, ex, oy, ey)
 
         return gn.Map(name=self.name()+"_operation", **kwargs, func=func)
 


### PR DESCRIPTION
1) When dealing with a rotated image in the ROI 2D box, the ROI is applied on the non-rotated images. This PR fixes this.

2) Use to row-major.

3) Add an option to lock the aspect ratio of the image.