### PR TITLE
Clean up and reorganize export boxes.

### DIFF
--- a/ami/data.py
+++ b/ami/data.py
@@ -392,6 +392,8 @@ class RequestedData:
         req.add(name, kwargs=kws)
         return req
 
+    def __contains__(self, name):
+        return name in self.names
 
 class Source(abc.ABC):
     def __init__(self, idnum, num_workers, heartbeat_period, src_cfg, flags=None, evtid_type=None):

--- a/ami/export/__init__.py
+++ b/ami/export/__init__.py
@@ -3,7 +3,7 @@ import logging
 import argparse
 
 from ami import LogConfig, Defaults
-from ami.comm import Ports
+from ami.comm import Ports, PlatformAction
 from ami.export import server
 
 
@@ -26,19 +26,12 @@ def main():
     )
 
     parser.add_argument(
-        '-e',
-        '--export',
+        '-p',
+        '--port',
         type=int,
-        default=Ports.Export,
-        help='port for receiving data to export (default: %d)' % Ports.Export
-    )
-
-    parser.add_argument(
-        '-c',
-        '--comm',
-        type=int,
-        default=Ports.Comm,
-        help='port for DataExport-Manager communication (default: %d)' % Ports.Comm
+        default=Ports.BasePort,
+        action=PlatformAction,
+        help='base port for ami (default: %d) reserves next %d consecutive ports' % (Ports.BasePort, Ports.NumPorts)
     )
 
     parser.add_argument(
@@ -66,8 +59,8 @@ def main():
 
     args = parser.parse_args()
 
-    export_addr = "tcp://%s:%d" % (args.host, args.export)
-    comm_addr = "tcp://%s:%d" % (args.host, args.comm)
+    export_addr = "tcp://%s:%d" % (args.host, args.port + Ports.Export)
+    comm_addr = "tcp://%s:%d" % (args.host, args.port + Ports.Comm)
 
     log_handlers = [logging.StreamHandler()]
     if args.log_file is not None:

--- a/ami/flowchart/library/Export.py
+++ b/ami/flowchart/library/Export.py
@@ -5,6 +5,21 @@ from ami.flowchart.library.common import CtrlNode
 import ami.graph_nodes as gn
 
 
+class Export(CtrlNode):
+
+    """
+    Send data back to worker.
+    """
+
+    nodeName = "Export"
+    uiTemplate = [('alias', 'text')]
+
+    def __init__(self, name):
+        super().__init__(name, terminals={"In": {'io': 'in', 'ttype': Any},
+                                          "Out": {'io': 'out', 'ttype': Any}},
+                         exportable=True)
+
+
 class ZMQWidget(QtWidgets.QLabel):
 
     def __init__(self, topics=None, terms=None, addr=None, parent=None, **kwargs):

--- a/ami/flowchart/library/Export.py
+++ b/ami/flowchart/library/Export.py
@@ -5,18 +5,32 @@ from ami.flowchart.library.common import CtrlNode
 import ami.graph_nodes as gn
 
 
-class Export(CtrlNode):
+class ExportToWorker(CtrlNode):
 
     """
-    Send data back to worker.
+    Send data back to worker from global collector.
     """
 
-    nodeName = "Export"
-    uiTemplate = [('alias', 'text')]
+    nodeName = "ExportToWorker"
+    uiTemplate = [('alias', 'text', {'tip': "Name to export data under."})]
 
     def __init__(self, name):
         super().__init__(name, terminals={"In": {'io': 'in', 'ttype': Any},
                                           "Out": {'io': 'out', 'ttype': Any}},
+                         exportable=True)
+
+
+class PvExport(CtrlNode):
+
+    """
+    Export data through an AMI hosted PV using either PV access or channel access.
+    """
+
+    nodeName = "PvExport"
+    uiTemplate = [('alias', 'text', {'tip': "PV name to export variable under."})]
+
+    def __init__(self, name):
+        super().__init__(name, terminals={"In": {'io': 'in', 'ttype': Any}},
                          exportable=True)
 
 
@@ -58,27 +72,30 @@ class ZMQ(CtrlNode):
         return super().display(topics, terms, addr, win, ZMQWidget, **kwargs)
 
 try:
-    import epics
+    import caproto.threading.client as ct
 
     class CaputProc():
         def __init__(self, pvname):
             self.pvname = pvname
+            self.ctx = None
             self.pv = None
 
         def __call__(self, value):
-            if self.pv is None:
-                self.pv = epics.PV(self.pvname)
-            return self.pv.put(value)
+            if self.ctx is None:
+                self.ctx = ct.Context()
+                self.pv = self.ctx.get_pvs(self.pvname)[0]
+            return self.pv.write(value)
 
     class Caput(CtrlNode):
 
         """
-        Send data to a PV via Channel Access.
+        Send data to an existing externally hosted PV via Channel Access.
         """
 
         nodeName = "Caput"
         uiTemplate = [('pvname', 'text'),
-                      ('global', 'check', {'checked': True})]
+                      ('global', 'check', {'checked': True,
+                                           'tip': "Insert Pick1 and export values from global collector."})]
 
         def __init__(self, name):
             super().__init__(name, terminals={"In": {'io': 'in', 'ttype': Union[str, int, float, Array1d]}})
@@ -119,16 +136,17 @@ try:
     class Pvput(CtrlNode):
 
         """
-        Send data to a PV via PVAccess.
+        Send data to an existing externally hosted PV via PVAccess.
         """
 
         nodeName = "Pvput"
         uiTemplate = [('pvname', 'text'),
-                      ('global', 'check', {'checked': True})]
+                      ('global', 'check', {'checked': True,
+                                           'tip': "Insert Pick1 and export values from global collector."})]
 
         def __init__(self, name):
-            super().__init__(name, terminals={"In":
-                                              {'io': 'in', 'ttype': Union[str, int, float, Array1d, Array2d]}})
+            super().__init__(name,
+                             terminals={"In": {'io': 'in', 'ttype': Union[str, int, float, Array1d, Array2d]}})
 
         def to_operation(self, inputs, outputs, **kwargs):
             outputs = [self.name()+"_unused"]
@@ -147,7 +165,6 @@ try:
                                 func=PvputProc(self.values['pvname']), **kwargs)]
 
             return nodes
-
 
 except ImportError as e:
     print(e)

--- a/ami/flowchart/library/Export.py
+++ b/ami/flowchart/library/Export.py
@@ -1,7 +1,46 @@
-from typing import Union
+from typing import Union, Any
+from qtpy import QtCore, QtWidgets
 from amitypes import Array1d, Array2d
 from ami.flowchart.library.common import CtrlNode
 import ami.graph_nodes as gn
+
+
+class ZMQWidget(QtWidgets.QLabel):
+
+    def __init__(self, topics=None, terms=None, addr=None, parent=None, **kwargs):
+        super().__init__(parent)
+
+        topic_label = ""
+
+        if addr:
+            topic_label = f"Address: {addr.view}\n"
+
+        if terms:
+            for term, name in terms.items():
+                topic = topics[name]
+                sub_topic = "Sub Topic Name: view:%s:%s\\0" % (addr.name, topic)
+                topic_label += sub_topic + "\n"
+
+        self.setText(topic_label)
+        self.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
+
+
+class ZMQ(CtrlNode):
+
+    """
+    Export data over ZMQ PUB/SUB
+    """
+
+    nodeName = "ZMQ"
+    uiTemplate = []
+
+    def __init__(self, name):
+        super().__init__(name, terminals={"In": {'io': 'in', 'ttype': Any}},
+                         allowAddInput=True,
+                         viewable=True)
+
+    def display(self, topics, terms, addr, win, **kwargs):
+        return super().display(topics, terms, addr, win, ZMQWidget, **kwargs)
 
 try:
     import epics

--- a/ami/flowchart/library/Operators.py
+++ b/ami/flowchart/library/Operators.py
@@ -336,21 +336,6 @@ class Combinations(CtrlNode):
         return gn.Map(name=self.name()+"_operation", func=func, **kwargs)
 
 
-class Export(CtrlNode):
-
-    """
-    Send data back to worker.
-    """
-
-    nodeName = "Export"
-    uiTemplate = [('alias', 'text')]
-
-    def __init__(self, name):
-        super().__init__(name, terminals={"In": {'io': 'in', 'ttype': Any},
-                                          "Out": {'io': 'out', 'ttype': Any}},
-                         exportable=True)
-
-
 try:
     import sympy
 

--- a/ami/flowchart/library/Operators.py
+++ b/ami/flowchart/library/Operators.py
@@ -442,7 +442,7 @@ try:
             prompt.name = QtWidgets.QLineEdit(name, parent=prompt)
             prompt.type_selector = QtWidgets.QComboBox(prompt)
             prompt.ok = QtWidgets.QPushButton('Ok', parent=prompt)
-            for typ in [Any, bool, float, Array1d, Array2d, Array3d]:
+            for typ in [Any, bool, int, float, Array1d, Array2d, Array3d]:
                 prompt.type_selector.addItem(str(typ), typ)
             prompt.layout.addRow("Name:", prompt.name)
             prompt.layout.addRow("Type:", prompt.type_selector)

--- a/ami/flowchart/library/__init__.py
+++ b/ami/flowchart/library/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from ami.flowchart.NodeLibrary import NodeLibrary, isNodeClass
-from ami.flowchart.library import Roi, Operators, Display, Accumulators, Alert, Numpy, Epics, Validators
+from ami.flowchart.library import Roi, Operators, Display, Accumulators, Alert, Numpy, Export, Validators
 
-modules = [Roi, Operators, Display, Accumulators, Alert, Numpy, Epics, Validators]
+modules = [Roi, Operators, Display, Accumulators, Alert, Numpy, Export, Validators]
 
 try:
     from ami.flowchart.library import Scipy


### PR DESCRIPTION
This pull request adds support for ZMQ, UDP Multicast, and channel access export to an existing PV using caproto instead of pyepics. 

It also fixes exporting data from the global collector back to the workers as I discovered that was broken. 

Adding support for AMI to host channel access PVs will come in a separate pull request. 