### PR TITLE
dmypy fix for cwd permission issue

### DIFF
--- a/ami/client/flowchart.py
+++ b/ami/client/flowchart.py
@@ -34,9 +34,10 @@ pg.setConfigOption('imageAxisOrder', 'row-major')
 
 def run_editor_window(broker_addr, graphmgr_addr, checkpoint_addr, load=None, prometheus_dir=None,
                       prometheus_port=None, hutch=None, configure=False, save_dir=None):
-    dmypy_file = tempfile.NamedTemporaryFile(mode='w', delete=True)
+    dmypy_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
     os.environ['DMYPY_STATUS_FILE'] = dmypy_file.name
     logger.debug(f"dmypy status file: {dmypy_file.name}")
+    logger.info(f"dmypy status file: {dmypy_file.name}")
     subprocess.run(["dmypy", "--status-file", dmypy_file.name, "start"])
     check_file = None
     with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:

--- a/ami/client/flowchart.py
+++ b/ami/client/flowchart.py
@@ -37,7 +37,6 @@ def run_editor_window(broker_addr, graphmgr_addr, checkpoint_addr, load=None, pr
     dmypy_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
     os.environ['DMYPY_STATUS_FILE'] = dmypy_file.name
     logger.debug(f"dmypy status file: {dmypy_file.name}")
-    logger.info(f"dmypy status file: {dmypy_file.name}")
     subprocess.run(["dmypy", "--status-file", dmypy_file.name, "start"])
     check_file = None
     with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:

--- a/ami/flowchart/Terminal.py
+++ b/ami/flowchart/Terminal.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from qtpy import QtCore, QtGui, QtWidgets
 from pyqtgraph.graphicsItems.GraphicsObject import GraphicsObject
 from pyqtgraph import functions as fn
@@ -603,10 +604,11 @@ def checkType(terminals, type_file=None):
             f.write(f"def {f_out}:\n\t{f_out_return_string}")
             f.write(f"\n{f_in_name}({f_out_name}())")
             f.flush()
-            status = subprocess.call(["dmypy", "check", f.name])
+            dmypy_status = os.environ['DMYPY_STATUS_FILE']
+            status = subprocess.call(["dmypy", "--status-file", dmypy_status, "check", f.name])
             if status == 2:
-                subprocess.call(["dmypy", "start"])
-                status = subprocess.call(["dmypy", "check", f.name])
+                subprocess.call(["dmypy", "--status-file", dmypy_status, "start"])
+                status = subprocess.call(["dmypy", "--status-file", dmypy_status, "check", f.name])
             return status == 0
 
 


### PR DESCRIPTION
When launching the AMI client from a directory where the user does not have write permissions, the mypy deamon cannot create the default file it needs on the cwd. This prevent the type-checking from working on the terminals.

This PR addresses this by using a randomly created file in /tmp/