### PR TITLE
Add input latency to worker

### DIFF
--- a/ami/data.py
+++ b/ami/data.py
@@ -147,7 +147,7 @@ class Message:
     identity: int
     payload: dict
     timestamp: int = 0  # typically raw data source (LCLS) timestamp
-    unix_ts: int = 0  # timestamp converted to unix_ts
+    unix_ts: float = 0  # timestamp converted to unix_ts
 
     def _serialize(self):
         return asdict(self)

--- a/ami/data.py
+++ b/ami/data.py
@@ -3,6 +3,7 @@ import sys
 import abc
 import zmq
 import time
+import datetime as dt
 import dill
 import json
 import typing
@@ -24,6 +25,7 @@ import numpy as np
 import amitypes as at
 from enum import Enum
 from dataclasses import dataclass, asdict, field
+import prometheus_client as pc
 from ami import psana, psana_uses_epics_epoch
 
 
@@ -144,7 +146,8 @@ class Message:
     mtype: MsgTypes
     identity: int
     payload: dict
-    timestamp: int = 0
+    timestamp: int = 0  # typically raw data source (LCLS) timestamp
+    unix_ts: int = 0  # timestamp converted to unix_ts
 
     def _serialize(self):
         return asdict(self)
@@ -699,7 +702,7 @@ class Source(abc.ABC):
             ('source', self.source)
         ]
         data.update({k: v for k, v in base if k in self.requested_names.names})
-        msg = Message(mtype=MsgTypes.Datagram, identity=self.idnum, payload=data, timestamp=eventid)
+        msg = Message(mtype=MsgTypes.Datagram, identity=self.idnum, payload=data, timestamp=eventid, unix_ts=timestamp)
         yield msg
 
     def request(self, requested_data, is_kws_update=False):

--- a/ami/worker.py
+++ b/ami/worker.py
@@ -227,7 +227,7 @@ class Worker(Node):
                     datagram_start = time.time()
                     input_latency = dt.datetime.now() - dt.datetime.fromtimestamp(msg.unix_ts)
                     event_latency.labels(self.hutch, "Source",
-                                              self.name).set(input_latency.total_seconds())
+                                         self.name).set(input_latency.total_seconds())
 
                     if any(v is None for k, v in msg.payload.items()):
                         event_counter.labels(self.hutch, 'Partial', self.name).inc()

--- a/ami/worker.py
+++ b/ami/worker.py
@@ -225,9 +225,9 @@ class Worker(Node):
 
                 elif msg.mtype == MsgTypes.Datagram:
                     datagram_start = time.time()
-                    datagram_start_latency = dt.datetime.now() - dt.datetime.fromtimestamp(msg.heartbeat.timestamp)
+                    input_latency = dt.datetime.now() - dt.datetime.fromtimestamp(msg.unix_ts)
                     self.event_latency.labels(self.hutch, "Source",
-                                      self.name).set(datagram_start_latency.total_seconds())
+                                              self.name).set(input_latency.total_seconds())
 
                     if any(v is None for k, v in msg.payload.items()):
                         event_counter.labels(self.hutch, 'Partial', self.name).inc()


### PR DESCRIPTION
This will allow to disassociate the graph execution from latency on the data source.