### PR TITLE
ENH Support for psana.DataSource supervisor model.

### DIFF
--- a/ami/data.py
+++ b/ami/data.py
@@ -945,7 +945,10 @@ class PsanaSource(HierarchicalDataSource):
             'smd',
             'calibdir',
             'monitor',
-            'detectors'
+            'detectors',
+            'supervisor',
+            'supervisor_ip_addr',
+            'skip_calib_load',
         }
         # special attributes that are per run instead of per event from a detectors interface, e.g. calib constants
         self.special_attrs = {
@@ -969,7 +972,8 @@ class PsanaSource(HierarchicalDataSource):
             'live': lambda s: s if isinstance(s, bool) else s.lower() == 'true',
             'smd': lambda s: s if isinstance(s, bool) else s.lower() == 'true',
             'monitor': lambda s: s if isinstance(s, bool) else s.lower() == 'true',
-            'detectors': lambda s: s.split(';')
+            'detectors': lambda s: s.split(';'),
+            'supervisor': lambda s: int(s),
         }
         for key, func in convert_kwargs.items():
             if key in ps_kwargs:


### PR DESCRIPTION
# Description

This PR adds support for `psana.DataSource` keyword arguments for the "supervisor" model where only one core (the "supervisor") is used to load calibration constants from the database, and then shares it with other participating workers. This is done in the DataSource and requires no additional work in ami.

Placeholder support is provided for the `skip_calib_load` DataSource keyword argument which will be available in a future psana release, and skips the loading of the calibration constants all together.

## Usage:
Add the flag `--use_supervisor` to ami node processes.

Provide the following keyword arguments to the datasource for ami node processes: 
- `supervisor_ip_addr=NN.NN.NN.NN:YY` (This is the IP address of the node which will run the supervisor process)
- If using multiple nodes, also add `supervisor=0` to the nodes which will not run the supervisor process.

Example DAQ configuration entry for 1 node:
```
        procmgr_ami.append({ host:worker_node, id:f'ami-node_{N}_{instance}', flags:'s', env:epics_env,
                             cmd:f'ami-node -p {base_port} --hutch {hutch_meb}_{instance} --prometheus-dir {prom_dir} -N {N} -n {ami_workers_per_node} -H {ami_manager_node} --log-level info worker -b {heartbeat_period} --use_supervisor psana://shmem={hutch_meb}{instance},supervisor_ip_addr=172.21.152.80:29012' })
``` 

## Checklist
- [x] Supervisor model support
- [x] Placeholder for `skip_calib_load` keyword argument

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- Reduce calibration loading time by only making a single database request using the psana "supervisor" model already provided by the DataSource.

# Testing
Tested using DAQ configuration at `/cds/group/pcds/dist/pds/mfx/scripts/mfx.py` using DAQ release at `/cds/home/d/dorlhiac/Repos/lcls2_20250213`. Corresponding AMI release is at: `/cds/home/d/dorlhiac/Repos/ami_20250219`

# Screenshots
