### PR TITLE
Add cprofile support to worker, collectors, and manager.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ htmlcov/
 .agignore
 .gdb_history
 examples/*
+*.cprof

--- a/ami/local.py
+++ b/ami/local.py
@@ -201,6 +201,12 @@ def build_parser():
     )
 
     parser.add_argument(
+        '--cprofile',
+        help="profile with cprofile",
+        action='store_true'
+    )
+
+    parser.add_argument(
         '--use-opengl',
         help='Use opengl for plots.',
         action='store_true'
@@ -330,7 +336,7 @@ def run_ami(args, queue=None):
                 target=functools.partial(_sys_exit, run_worker),
                 args=(i, args.num_workers, args.heartbeat, src_cfg,
                       collector_addr, graph_addr, msg_addr, export_addr, flags, args.prometheus_dir,
-                      args.prometheus_port, args.hutch, args.hwm)
+                      args.prometheus_port, args.hutch, args.hwm, args.cprofile)
             )
             proc.daemon = True
             proc.start()
@@ -340,7 +346,7 @@ def run_ami(args, queue=None):
             name='nodecol-n0',
             target=functools.partial(_sys_exit, run_node_collector),
             args=(0, args.num_workers, args.eb_depth, collector_addr, globalcol_addr, graph_addr,
-                  msg_addr, args.prometheus_dir, args.prometheus_port, args.hutch, args.hwm)
+                  msg_addr, args.prometheus_dir, args.prometheus_port, args.hutch, args.hwm, args.cprofile)
         )
         collector_proc.daemon = True
         collector_proc.start()
@@ -350,7 +356,7 @@ def run_ami(args, queue=None):
             name='globalcol',
             target=functools.partial(_sys_exit, run_global_collector),
             args=(0, 1, args.eb_depth, globalcol_addr, results_addr, graph_addr, msg_addr,
-                  args.prometheus_dir, args.prometheus_port, args.hutch, args.hwm)
+                  args.prometheus_dir, args.prometheus_port, args.hutch, args.hwm, args.cprofile)
         )
         globalcol_proc.daemon = True
         globalcol_proc.start()
@@ -360,7 +366,7 @@ def run_ami(args, queue=None):
             name='manager',
             target=functools.partial(_sys_exit, run_manager),
             args=(args.num_workers, 1, results_addr, graph_addr, comm_addr, msg_addr, info_addr, export_addr,
-                  view_addr, args.prometheus_dir, args.prometheus_port, args.hutch, args.hwm)
+                  view_addr, args.prometheus_dir, args.prometheus_port, args.hutch, args.hwm, args.cprofile)
         )
         manager_proc.daemon = True
         manager_proc.start()


### PR DESCRIPTION
This probably only really useful for the workers, but it wasnt that difficult to add to the collectors and manager. It allows us to see the full stack in the workers from ami down to psana. 

Here is an example from the worker running an mfx run offline:
![2025-05-02-051415_1918x2350_scrot](https://github.com/user-attachments/assets/ce888a40-e918-4b6b-81dd-fd8ef9673983)

![2025-05-02-051857_1918x2350_scrot](https://github.com/user-attachments/assets/5a925650-2935-42bc-9a9b-7fff34a041c4)
