### PR TITLE
ENH Add support for psana calib cache/prefetch.

### DIFF
--- a/ami/data.py
+++ b/ami/data.py
@@ -952,6 +952,8 @@ class PsanaSource(HierarchicalDataSource):
             'supervisor',
             'supervisor_ip_addr',
             'skip_calib_load',
+            'use_calib_cache',
+            'cached_detectors',
         }
         # special attributes that are per run instead of per event from a detectors interface, e.g. calib constants
         self.special_attrs = {
@@ -977,6 +979,8 @@ class PsanaSource(HierarchicalDataSource):
             'monitor': lambda s: s if isinstance(s, bool) else s.lower() == 'true',
             'detectors': lambda s: s.split(';'),
             'supervisor': lambda s: int(s),
+            'use_calib_cache': lambda s: s if isinstance(s, bool) else s.lower() == 'true',
+            'cached_detectors': lambda s: s.split(';'),
         }
         for key, func in convert_kwargs.items():
             if key in ps_kwargs:


### PR DESCRIPTION
# Description

This PR adds support for `psana.DataSource` keyword arguments for the calibration prefetch.

## Usage:

Provide the following keyword arguments to the datasource for ami node processes: 
- `use_calib_cache=True` : Turns on use of the prefetched calibration constants.
- `cached_detectors=det1;det2;...;det3` : A semi-colon delimited list of detectors.

A calibration prefetcher must be running on the same node that the AMI process is running on (since it will check for a file in the RAM disk).

Example DAQ configuration entry for 1 node:
```
        procmgr_ami.append({ host:worker_node, id:f"ami-node_{N}_{instance}", flags:"s", env:epics_env,
                             cmd:f"ami-node -p {base_port} --hutch {hutch_meb}_{instance} --prometheus-dir {prom_dir} -N {N} -n {ami_workers_per_node} -H {ami_manager_node} --log-level info --hwm {ami_hwm} -d {ami_eb_depth} worker -b {heartbeat_period} --use_supervisor psana://shmem={hutch_meb}{instance},supervisor_ip_addr=172.21.152.82:29012,use_calib_cache=True,cached_detectors=jungfrau", cores:10 })
``` 

## Checklist
- [x] Calibration prefetch support

## PR Type:
- [x] New feature/Enhancement

## Address issues:
- Reduce calibration loading time by only making a single database request using the psana "supervisor" model already provided by the DataSource.

# Testing
Tested using DAQ configuration at `/cds/group/pcds/dist/pds/mfx/scripts/mfx_prefetch.py` using DAQ release at `/cds/home/d/dorlhiac/Repos/lcls2_20250213`. Corresponding AMI release is at: `/cds/home/d/dorlhiac/Repos/ami_20250219`

Prefetching not fully working in test case because no Jungfrau detector available, but this is not an AMI issue.

# Screenshots
