### PR TITLE
Add FC smoke tests with binary source alternation

### DIFF
--- a/ami/client/flowchart.py
+++ b/ami/client/flowchart.py
@@ -226,7 +226,7 @@ class NodeProcess(QtCore.QObject):
         self.headless = headless
 
         if loop is None:
-            self.app = QtWidgets.QApplication([])
+            self.app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
 
             if THEME:
                 qdarktheme.setup_theme(THEME)

--- a/ami/client/flowchart.py
+++ b/ami/client/flowchart.py
@@ -583,7 +583,9 @@ class MessageBroker(object):
 
                     msg = fcMsgs.CreateNode(name, typ, state)
 
-                    if type(self.msgs[msg.name]) is fcMsgs.DisplayNode and state:
+                    if msg.name not in self.msgs:
+                        pass  # Widget died before DisplayNode message was stored
+                    elif type(self.msgs[msg.name]) is fcMsgs.DisplayNode and state:
                         self.msgs[msg.name].state = state["widget"]
                     else:
                         # don't resend last message

--- a/ami/data.py
+++ b/ami/data.py
@@ -1695,10 +1695,17 @@ class StaticSource(SimSource):
                 yield self.heartbeat_msg()
             for name, config in self.simulated.items():
                 if name in self.requested_data.names:
+                    is_binary = config.get("binary", False)
                     if config["dtype"] == "Scalar":
-                        event[name] = 1
+                        if is_binary:
+                            event[name] = 1 if count % 2 == 0 else 0
+                        else:
+                            event[name] = 1
                     elif config["dtype"] == "Waveform" or config["dtype"] == "Image":
-                        event[name] = np.ones(config["shape"])
+                        if is_binary:
+                            event[name] = np.ones(config["shape"]) if count % 2 == 0 else np.zeros(config["shape"])
+                        else:
+                            event[name] = np.ones(config["shape"])
                     else:
                         logger.warn("DataSrc: %s has unknown type %s", name, config["dtype"])
             count += 1

--- a/ami/fc_to_worker.py
+++ b/ami/fc_to_worker.py
@@ -54,6 +54,9 @@ def extract_sources_from_fc(fc_path):
     return sources
 
 
+BINARY_SOURCES = {"timing:raw:eventcodes", "laser"}
+
+
 def map_amitypes_to_config(ttype, source_name=""):
     """
     Map amitypes type string to static source config.
@@ -76,13 +79,15 @@ def map_amitypes_to_config(ttype, source_name=""):
         return {"dtype": "Image", "pedestal": 5, "width": 1, "shape": [512, 512]}
     elif "Array1d" in ttype:
         # Special handling for timing event codes
-        if source_name == "timing:raw:eventcodes":
+        if source_name in BINARY_SOURCES:
             return {"dtype": "Waveform", "pedestal": 0, "width": 0, "shape": [300], "binary": True}
         else:
             return {"dtype": "Waveform", "pedestal": 5, "width": 1, "shape": [1024]}
     elif "Array3d" in ttype:
         return {"dtype": "Image", "pedestal": 5, "width": 1, "shape": [100, 512, 512]}
     elif "int" in ttype.lower():
+        if source_name in BINARY_SOURCES:
+            return {"dtype": "Scalar", "range": [0, 2], "integer": True, "binary": True}
         return {"dtype": "Scalar", "range": [0, 100], "integer": True}
     elif "float" in ttype.lower():
         return {"dtype": "Scalar", "range": [0.0, 100.0]}

--- a/examples/sim_src.json
+++ b/examples/sim_src.json
@@ -1,7 +1,7 @@
 {
     "delta_t": {"dtype": "Scalar", "range": [0,10], "integer": true},
     "cspad": {"dtype": "Image", "pedestal": 5, "width": 1, "shape": [1024, 1024]},
-    "laser": {"dtype": "Scalar", "range": [0,2], "integer": true},
+    "laser": {"dtype": "Scalar", "range": [0,2], "integer": true, "binary": true},
     "waveform": {"dtype": "Waveform", "pedestal": 5, "width": 1, "shape": [1024]},
     "waveform2": {"dtype": "Waveform", "pedestal": 10, "width": 2, "shape": [1024]}
 }

--- a/examples/worker.json
+++ b/examples/worker.json
@@ -8,7 +8,7 @@
     "config": {
         "delta_t": {"dtype": "Scalar", "range": [0,10], "integer": true},
         "cspad": {"dtype": "Image", "pedestal": 5, "width": 1, "shape": [1024, 1024]},
-        "laser": {"dtype": "Scalar", "range": [0,2], "integer": true},
+        "laser": {"dtype": "Scalar", "range": [0,2], "integer": true, "binary": true},
         "waveform": {"dtype": "Waveform", "pedestal": 5, "width": 1, "shape": [1024]},
         "waveform2": {"dtype": "Waveform", "pedestal": 100, "width": 2, "shape": [1024]},
         "eventCodes": {"dtype": "List", "range": [100, 300], "type": "integer", "shape": [10]}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def workerjson(tmpdir_factory, xtcwriter):
     default_sources = {
         # Sources for test_complex_graph (also in examples/complex_example.fc)
         "cspad": {"dtype": "Image", "pedestal": 5, "width": 1, "shape": [512, 512]},
-        "laser": {"dtype": "Scalar", "range": [0, 2], "integer": True},
+        "laser": {"dtype": "Scalar", "range": [0, 2], "integer": True, "binary": True},
         "delta_t": {"dtype": "Scalar", "range": [0, 10], "integer": True},
         # Sources for test_psana_graph (psana-specific, not in any .fc)
         "xppcspad:raw:image": {
@@ -472,13 +472,18 @@ def broker(ami_backend):
     broker_running = threading.Event()
 
     # Run the broker in a background thread with its own event loop
+    broker_exception = None
+
     def run_broker():
+        nonlocal broker_exception
         asyncio.set_event_loop(broker_loop)
         broker_running.set()  # Signal that the broker has started
         try:
             broker_loop.run_until_complete(mb.run())
         except (asyncio.CancelledError, RuntimeError):
             pass  # Expected when we cancel the broker or stop the loop
+        except Exception as e:
+            broker_exception = e
 
     broker_thread = threading.Thread(target=run_broker, daemon=True)
     broker_thread.start()
@@ -535,6 +540,9 @@ def broker(ami_backend):
             shutil.rmtree(ipcdir)
         except Exception:
             pass
+
+    if broker_exception is not None:
+        pytest.fail(f"Broker thread raised exception: {broker_exception}")
 
 
 @pytest.fixture(scope="module")

--- a/tests/graphs/LODCM_rocking_curve.fc
+++ b/tests/graphs/LODCM_rocking_curve.fc
@@ -1,0 +1,1523 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "Sp1L2Wv8:raw:peakAmplitude",
+      "state": {
+        "pos": [
+          0.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Sp1L2Wv8:raw:peakAmplitude"
+          },
+          "legend": {
+            "trace.0": [
+              "Sp1L2Wv8:raw:peakAmplitude",
+              "Sp1L2Wv8:raw:peakAmplitude",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 2,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -0.5885230971765428,
+                15.588523097176544
+              ],
+              [
+                -5.933211148862844,
+                128.93321114886285
+              ]
+            ],
+            "viewRange": [
+              [
+                -0.5885230971765428,
+                15.588523097176544
+              ],
+              [
+                -5.933211148862844,
+                128.93321114886285
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000000000000001b000003290000035c00000005000000380000032400000357000000000000000005e800000005000000380000032400000357",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "sp1l2_t1ry",
+      "state": {
+        "pos": [
+          0.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000001c700000121200001f8f0000154d00001c700000122e00001f8f0000154d00000002000000000a0000001c700000122e00001f8f0000154d",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "Em3l0BmMon:raw:totalIntensityJoules",
+      "state": {
+        "pos": [
+          0.0,
+          -200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb00030000000000000000009400000329000003d500000005000000b100000324000003d0000000000000000005e800000005000000b100000324000003d0",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.0",
+      "state": {
+        "pos": [
+          200.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "class EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, In, *args, **kwargs):\n        return In[6]"
+        },
+        "geometry": "01d9d0cb0003000000001c510000121a00001f70000014a700001c510000121a00001f70000014a700000002000000000a0000001c510000121a00001f70000014a7"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.1",
+      "state": {
+        "pos": [
+          300.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, In, *args, **kwargs):\n        # return 1 output(s)\n        return In[4]"
+        },
+        "geometry": "01d9d0cb00030000000019d3000011b700001cf2000014d6000019d3000011b700001cf2000014d600000002000000000a00000019d3000011b700001cf2000014d6"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.0",
+      "state": {
+        "pos": [
+          400.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.0",
+      "state": {
+        "pos": [
+          400.0,
+          -100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 100,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.0.Out vs Em3l0BmMon:raw:totalIntensityJoules"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.0.Out vs Em3l0BmMon:raw:totalIntensityJoules",
+              "PythonEditor.0.Out vs Em3l0BmMon:raw:totalIntensityJoules",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                2123.4241482137436,
+                7005.57585178626
+              ],
+              [
+                -97.45401947843084,
+                3116.817655842067
+              ]
+            ],
+            "viewRange": [
+              [
+                2123.4241482137436,
+                7005.57585178626
+              ],
+              [
+                -97.45401947843084,
+                3116.817655842067
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000001e3700001155000021550000149000001e3700001171000021550000149000000002000000000a0000001e37000011710000215500001490"
+      }
+    },
+    {
+      "class": "ScalarPlot",
+      "name": "ScalarPlot.0",
+      "state": {
+        "pos": [
+          500.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 100
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.0.Out",
+              "PythonEditor.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 2,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -1.1503599712666335,
+                26.15035997126663
+              ],
+              [
+                60.400768750036654,
+                412.7810494317832
+              ]
+            ],
+            "viewRange": [
+              [
+                -1.1503599712666335,
+                26.15035997126663
+              ],
+              [
+                60.400768750036654,
+                412.7810494317832
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000002be00000094000005e7000003d5000002c3000000b1000005e2000003d0000000000000000005e8000002c3000000b1000005e2000003d0"
+      }
+    },
+    {
+      "class": "ScalarPlot",
+      "name": "ScalarPlot.1",
+      "state": {
+        "pos": [
+          600.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 1000
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.1.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.1.Out",
+              "PythonEditor.1.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 2,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -2.807810306895566,
+                64.80781030689556
+              ],
+              [
+                10.940033543131241,
+                47.4236028205048
+              ]
+            ],
+            "viewRange": [
+              [
+                -2.807810306895566,
+                64.80781030689556
+              ],
+              [
+                10.940033543131241,
+                47.4236028205048
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000002be0000001b000005e70000035c000002c300000038000005e200000357000000000000000005e8000002c300000038000005e200000357"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.0",
+      "state": {
+        "pos": [
+          700.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "MeanVsScan.0.Counts vs MeanVsScan.0.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 5,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                7.483151893501214,
+                7.580832106498791
+              ],
+              [
+                -521.8781824506077,
+                16526.354548423096
+              ]
+            ],
+            "viewRange": [
+              [
+                7.483151893501214,
+                7.580832106498791
+              ],
+              [
+                -521.8781824506077,
+                16526.354548423096
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000001eaf0000137b000021ce000015ee00001eaf00001397000021ce000015ee00000002000000000a0000001eaf00001397000021ce000015ee"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.1",
+      "state": {
+        "pos": [
+          700.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.1",
+      "state": {
+        "pos": [
+          900.0,
+          700.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 100,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.1.Out vs sp1l2_t2ry_fine"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.1.Out vs sp1l2_t2ry_fine",
+              "PythonEditor.1.Out vs sp1l2_t2ry_fine",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                15.900000000000002,
+                16.900000000000002
+              ],
+              [
+                -3.337108658064678,
+                163.70074502170073
+              ]
+            ],
+            "viewRange": [
+              [
+                15.900000000000002,
+                16.900000000000002
+              ],
+              [
+                -3.337108658064678,
+                163.70074502170073
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000001100000029000002e3000001ac0000001600000046000002de000001a7000000000000000005e80000001600000046000002de000001a7"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.1",
+      "state": {
+        "pos": [
+          1100.0,
+          1000.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "MeanVsScan.1.Counts vs MeanVsScan.1.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+              "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 5,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                16.202852349412876,
+                20.194347650587126
+              ],
+              [
+                25.228437115822416,
+                28.26229713270755
+              ]
+            ],
+            "viewRange": [
+              [
+                16.202852349412876,
+                20.194347650587126
+              ],
+              [
+                25.228437115822416,
+                28.26229713270755
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000037000001d8000001b0000003420000003c000001f5000001ab0000033d000000000000000005e80000003c000001f5000001ab0000033d"
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "sp1l2_t2ry_fine",
+      "state": {
+        "pos": [
+          300.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb00030000000002be0000001b000005e70000035c000002c300000038000005e200000357000000000000000005e8000002c300000038000005e200000357",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "ScalarPlot",
+      "name": "ScalarPlot.2",
+      "state": {
+        "pos": [
+          700.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 100
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "sp1l2_t2ry_fine"
+          },
+          "legend": {
+            "trace.0": [
+              "sp1l2_t2ry_fine",
+              "sp1l2_t2ry_fine",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 2,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -40.23894052900833,
+                135.81776394005908
+              ],
+              [
+                16.870441484536492,
+                17.649941726397724
+              ]
+            ],
+            "viewRange": [
+              [
+                -40.23894052900833,
+                135.81776394005908
+              ],
+              [
+                16.870441484536492,
+                17.649941726397724
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000007b00000094000003a4000003d500000080000000b10000039f000003d0000000000000000005e800000080000000b10000039f000003d0"
+      }
+    }
+  ],
+  "connects": [
+    [
+      "Sp1L2Wv8:raw:peakAmplitude",
+      "Out",
+      "PythonEditor.0",
+      "In"
+    ],
+    [
+      "Sp1L2Wv8:raw:peakAmplitude",
+      "Out",
+      "PythonEditor.1",
+      "In"
+    ],
+    [
+      "sp1l2_t1ry",
+      "Out",
+      "MeanVsScan.0",
+      "Bin"
+    ],
+    [
+      "Em3l0BmMon:raw:totalIntensityJoules",
+      "Out",
+      "ScatterPlot.0",
+      "X"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "MeanVsScan.0",
+      "Value"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "ScalarPlot.0",
+      "Y"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "ScatterPlot.0",
+      "Y"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "MeanVsScan.1",
+      "Value"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "ScalarPlot.1",
+      "Y"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "ScatterPlot.1",
+      "Y"
+    ],
+    [
+      "MeanVsScan.0",
+      "Bins",
+      "LinePlot.0",
+      "X"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts",
+      "LinePlot.0",
+      "Y"
+    ],
+    [
+      "MeanVsScan.1",
+      "Counts",
+      "LinePlot.1",
+      "Y"
+    ],
+    [
+      "MeanVsScan.1",
+      "Bins",
+      "LinePlot.1",
+      "X"
+    ],
+    [
+      "sp1l2_t2ry_fine",
+      "Out",
+      "ScatterPlot.1",
+      "X"
+    ],
+    [
+      "sp1l2_t2ry_fine",
+      "Out",
+      "MeanVsScan.1",
+      "Bin"
+    ],
+    [
+      "sp1l2_t2ry_fine",
+      "Out",
+      "ScalarPlot.2",
+      "Y"
+    ]
+  ],
+  "viewbox": {
+    "comments": []
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": []
+  }
+}

--- a/tests/graphs/Rousseau.fc
+++ b/tests/graphs/Rousseau.fc
@@ -1,0 +1,2646 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "jungfrau:raw:image",
+      "state": {
+        "pos": [
+          0.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1637.5526539983966,
+                4226.910538316495
+              ],
+              [
+                1496.76285797519,
+                3950.0144048276175
+              ]
+            ],
+            "viewRange": [
+              [
+                1637.5526539983966,
+                4226.910538316495
+              ],
+              [
+                1496.76285797519,
+                3950.0144048276175
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0.15739202165330113,
+              624.3413466217941
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000001e34000000c9000023950000069100001e34000000e7000023950000069100000003000000000c0000001e34000000e70000239500000691",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "timestamp",
+      "state": {
+        "pos": [
+          0.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "acromag_O2_Sensor_ch12",
+      "state": {
+        "pos": [
+          0.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "Average2D",
+      "name": "Average2D.0",
+      "state": {
+        "pos": [
+          200.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 30,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000a5a00000a0600000d7900000d4a00000a5a00000a2b00000d7900000d4a00000000000000000a0000000a5a00000a2b00000d7900000d4a"
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "feespec:raw:hproj",
+      "state": {
+        "pos": [
+          200.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                0,
+                1
+              ],
+              [
+                0,
+                1
+              ]
+            ],
+            "viewRange": [
+              [
+                0,
+                1
+              ],
+              [
+                0,
+                1
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000f00000000000000121f0000033d00000f000000001e0000121f0000033d00000004000000000c0000000f000000001e0000121f0000033d",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "Calculator",
+      "name": "Calculator.0",
+      "state": {
+        "pos": [
+          200.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "operation": "acromag_O2_Sensor_ch12*1000/5"
+        },
+        "geometry": "01d9d0cb000300000000030b000009190000062a00000c5d0000030b0000093e0000062a00000c5d00000002000000000a000000030b0000093e0000062a00000c5d"
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "ebeamh:raw:ebeamPhotonEnergy",
+      "state": {
+        "pos": [
+          300.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000001400000008700000171f00000bb400001400000008950000171f00000bb400000001000000000a0000001400000008950000171f00000bb4",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "feespec:raw:integral",
+      "state": {
+        "pos": [
+          300.0,
+          700.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000001400000008700000171f00000bad000014000000088e0000171f00000bad00000001000000000800000014000000088e0000171f00000bad",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "eBeam_energy_loss_converted_to_photon_mJ",
+      "state": {
+        "pos": [
+          300.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000000f00000000000000121f0000033d00000f000000001e0000121f0000033d00000004000000000c0000000f000000001e0000121f0000033d",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "MfxDg1BmMon:raw:totalIntensityJoules",
+      "state": {
+        "pos": [
+          300.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "RoiArch",
+      "name": "RoiArch.0",
+      "state": {
+        "pos": [
+          400.0,
+          -200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "image": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "RBinCent": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "ABinCent": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "RBinEdges": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "ABinEdges": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "RadAngNormIntens": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "RadAngBinStatist": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "RProj": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "AProj": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "ROIPars": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "BBox": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Mask": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "center x": 2219,
+          "center y": 2106,
+          "radius o": 864,
+          "radius i": 518,
+          "angdeg o": 22,
+          "angdeg i": 343,
+          "nbins rad": 1,
+          "nbins ang": 1
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "annotations": {
+            "LineEditor.0": {
+              "name": "",
+              "From": {
+                "X": 0.0,
+                "Y": 0.0
+              },
+              "To": {
+                "X": 0.0,
+                "Y": 0.0
+              },
+              "Point": {
+                "symbol": "o",
+                "Brush": [
+                  0,
+                  0,
+                  255,
+                  255
+                ],
+                "Size": 14
+              },
+              "Line": {
+                "color": [
+                  128,
+                  128,
+                  128,
+                  255
+                ],
+                "width": 1,
+                "style": "Solid"
+              }
+            },
+            "LineEditor.1": {
+              "name": "",
+              "From": {
+                "X": 0.0,
+                "Y": -4.0
+              },
+              "To": {
+                "X": -1.0,
+                "Y": 0.0
+              },
+              "Point": {
+                "symbol": "o",
+                "Brush": [
+                  0,
+                  0,
+                  255,
+                  255
+                ],
+                "Size": 14
+              },
+              "Line": {
+                "color": [
+                  128,
+                  128,
+                  128,
+                  255
+                ],
+                "width": 1,
+                "style": "Solid"
+              }
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1771.5911473850756,
+                3174.709139429686
+              ],
+              [
+                1578.214319346172,
+                3050.5725918366143
+              ]
+            ],
+            "viewRange": [
+              [
+                1771.5911473850756,
+                3174.709139429686
+              ],
+              [
+                1578.214319346172,
+                3050.5725918366143
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.3333,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6666,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              42.27528306513523,
+              1809.1210012782649
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb00030000000010160000028b000015560000068300001016000002a9000015560000068300000004000000000c0000001016000002a90000155600000683"
+      }
+    },
+    {
+      "class": "ImageViewer",
+      "name": "ImageViewer.0",
+      "state": {
+        "pos": [
+          400.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                430.4769096102036,
+                3873.773538873712
+              ],
+              [
+                258.70866356768875,
+                3551.064031692732
+              ]
+            ],
+            "viewRange": [
+              [
+                430.4769096102036,
+                3873.773538873712
+              ],
+              [
+                258.70866356768875,
+                3551.064031692732
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.366917578596389,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6945884572188599,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0.0066857688634192934,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0.05573211140020362,
+              1729.8667500396625
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000000000000031f0000031f00000000000000000000031f0000031f00000005000000000c0000000000000000000000031f0000031f"
+      }
+    },
+    {
+      "class": "Average1D",
+      "name": "Average1D.0",
+      "state": {
+        "pos": [
+          400.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 20,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000f2400000024000012430000036100000f2400000042000012430000036100000004000000000c0000000f24000000420000124300000361"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.1",
+      "state": {
+        "pos": [
+          500.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 100,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "feespec:raw:integral vs ebeamh:raw:ebeamPhotonEnergy"
+          },
+          "legend": {
+            "trace.0": [
+              "feespec:raw:integral vs MfxDg1BmMon:raw:totalIntensityJoules",
+              "feespec:raw:integral vs ebeamh:raw:ebeamPhotonEnergy",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                80.57869652982606,
+                127.53668808556051
+              ],
+              [
+                108675.10586095083,
+                4927453.894139049
+              ]
+            ],
+            "viewRange": [
+              [
+                80.57869652982606,
+                127.53668808556051
+              ],
+              [
+                108675.10586095083,
+                4927453.894139049
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000016940000005a000019ed00000379000016940000005a000019ed0000037900000004000000000f00000016940000005a000019ed00000379"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.1",
+      "state": {
+        "pos": [
+          500.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 10,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000001400000008700000171f00000bad000014000000088e0000171f00000bad00000001000000000800000014000000088e0000171f00000bad"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.3",
+      "state": {
+        "pos": [
+          500.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 30,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000032000008b00000035100000bf400000032000008d50000035100000bf400000002000000000a0000000032000008d50000035100000bf4"
+      }
+    },
+    {
+      "class": "Sum",
+      "name": "Sum.0",
+      "state": {
+        "pos": [
+          600.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[amitypes.array.Array3d, amitypes.array.Array2d, amitypes.array.Array1d, list[float]]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        }
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "MfxDg2BmMon:raw:totalIntensityJoules",
+      "state": {
+        "pos": [
+          600.0,
+          -100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.0",
+      "state": {
+        "pos": [
+          600.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Average1D.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Average1D.0.Out",
+              "Average1D.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -78.19648859049559,
+                2125.196488590496
+              ],
+              [
+                -197.71232193847814,
+                5185.412126721346
+              ]
+            ],
+            "viewRange": [
+              [
+                -78.19648859049559,
+                2125.196488590496
+              ],
+              [
+                -197.71232193847814,
+                5185.412126721346
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000136c000000720000168b000003910000136c000000720000168b0000039100000004000000000f000000136c000000720000168b00000391"
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "HxxDg1BmMon:raw:totalIntensityJoules",
+      "state": {
+        "pos": [
+          600.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.0",
+      "state": {
+        "pos": [
+          800.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 10,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000001400000008700000171f00000bad000014000000088e0000171f00000bad00000001000000000800000014000000088e0000171f00000bad"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.2",
+      "state": {
+        "pos": [
+          800.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 10,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000001400000008700000171f00000bad000014000000088e0000171f00000bad00000001000000000800000014000000088e0000171f00000bad"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.0",
+      "state": {
+        "pos": [
+          800.0,
+          -200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, In, *args, **kwargs):\n\n        # return 1 output(s)\n        return np.sum(In)"
+        },
+        "geometry": "01d9d0cb0003000000000ff80000091e0000131700000c6200000ff8000009430000131700000c6200000000000000000a0000000ff8000009430000131700000c62"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.0",
+      "state": {
+        "pos": [
+          900.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 50,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Sum.0.Out vs MfxDg1BmMon:raw:totalIntensityJoules"
+          },
+          "legend": {
+            "trace.0": [
+              "Sum.0.Out vs MfxDg2BmMon:raw:totalIntensityJoules",
+              "Sum.0.Out vs MfxDg1BmMon:raw:totalIntensityJoules",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                6652.2750271561645,
+                44142.489400943916
+              ],
+              [
+                -54.48535864854415,
+                1380.6098922176743
+              ]
+            ],
+            "viewRange": [
+              [
+                6652.2750271561645,
+                44142.489400943916
+              ],
+              [
+                -54.48535864854415,
+                1380.6098922176743
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000f1c00000032000014bf0000058d00000f1c00000032000014bf0000058d00000004000000000f0000000f1c00000032000014bf0000058d"
+      }
+    },
+    {
+      "class": "ScalarPlot",
+      "name": "ScalarPlot.1",
+      "state": {
+        "pos": [
+          900.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 100
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "acromag_O2_Sensor_ch12"
+          },
+          "legend": {
+            "trace.0": [
+              "Average0D.3.Out",
+              "acromag_O2_Sensor_ch12",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 5,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -0.23598038534054822,
+                7.235980385340548
+              ],
+              [
+                364.43019374497675,
+                367.09446445814825
+              ]
+            ],
+            "viewRange": [
+              [
+                -0.23598038534054822,
+                7.235980385340548
+              ],
+              [
+                364.43019374497675,
+                367.09446445814825
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000009710000052300000ed100000867000009710000054800000ed10000086700000005000000000f00000009710000054800000ed100000867"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.2",
+      "state": {
+        "pos": [
+          1000.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 10000,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "MfxDg1BmMon:raw:totalIntensityJoules vs timestamp"
+          },
+          "legend": {
+            "trace.0": [
+              "Average0D.1.Out vs timestamp",
+              "MfxDg1BmMon:raw:totalIntensityJoules vs timestamp",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1771799385.0544136,
+                1771799418.6898844
+              ],
+              [
+                102.07708932192432,
+                116.68060298576934
+              ]
+            ],
+            "viewRange": [
+              [
+                1771799385.0544136,
+                1771799418.6898844
+              ],
+              [
+                102.07708932192432,
+                116.68060298576934
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000000160000050e0000036f0000082d000000160000050e0000036f0000082d00000005000000000f00000000160000050e0000036f0000082d"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.3",
+      "state": {
+        "pos": [
+          1000.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 10000,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "MfxDg2BmMon:raw:totalIntensityJoules vs timestamp"
+          },
+          "legend": {
+            "trace.0": [
+              "Average0D.2.Out vs timestamp",
+              "MfxDg2BmMon:raw:totalIntensityJoules vs timestamp",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1771799385.2335286,
+                1771799415.5368514
+              ],
+              [
+                -4.917174986703125,
+                1.1796749867031242
+              ]
+            ],
+            "viewRange": [
+              [
+                1771799385.2335286,
+                1771799415.5368514
+              ],
+              [
+                -4.917174986703125,
+                1.1796749867031242
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000792000002da00000aeb000005f900000792000002da00000aeb000005f900000005000000000f0000000792000002da00000aeb000005f9"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.4",
+      "state": {
+        "pos": [
+          1000.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 10000,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "HxxDg1BmMon:raw:totalIntensityJoules vs timestamp"
+          },
+          "legend": {
+            "trace.0": [
+              "Average0D.0.Out vs timestamp",
+              "HxxDg1BmMon:raw:totalIntensityJoules vs timestamp",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1765651337.2883837,
+                1765651566.7024252
+              ],
+              [
+                -12641.562750115945,
+                250198.12525011596
+              ]
+            ],
+            "viewRange": [
+              [
+                1765651337.2883837,
+                1765651566.7024252
+              ],
+              [
+                -12641.562750115945,
+                250198.12525011596
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000003140000035e0000066d0000067d000003140000035e0000066d0000067d00000005000000000f00000003140000035e0000066d0000067d"
+      }
+    },
+    {
+      "class": "ScalarPlot",
+      "name": "ScalarPlot.0",
+      "state": {
+        "pos": [
+          1100.0,
+          -200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 500
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.0.Out",
+              "PythonEditor.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -18.398369613389736,
+                517.3983696133897
+              ],
+              [
+                -3021.7621066998436,
+                8889.682931228617
+              ]
+            ],
+            "viewRange": [
+              [
+                -18.398369613389736,
+                517.3983696133897
+              ],
+              [
+                -3021.7621066998436,
+                8889.682931228617
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000019e10000005e00001dff0000037d000019e10000005e00001dff0000037d00000004000000000f00000019e10000005e00001dff0000037d"
+      }
+    }
+  ],
+  "connects": [
+    [
+      "jungfrau:raw:image",
+      "Out",
+      "Average2D.0",
+      "In"
+    ],
+    [
+      "jungfrau:raw:image",
+      "Out",
+      "RoiArch.0",
+      "image"
+    ],
+    [
+      "timestamp",
+      "Out",
+      "ScatterPlot.2",
+      "X"
+    ],
+    [
+      "timestamp",
+      "Out",
+      "ScatterPlot.3",
+      "X"
+    ],
+    [
+      "timestamp",
+      "Out",
+      "ScatterPlot.4",
+      "X"
+    ],
+    [
+      "acromag_O2_Sensor_ch12",
+      "Out",
+      "Calculator.0",
+      "In"
+    ],
+    [
+      "Average2D.0",
+      "Out",
+      "ImageViewer.0",
+      "In"
+    ],
+    [
+      "feespec:raw:hproj",
+      "Out",
+      "Average1D.0",
+      "In"
+    ],
+    [
+      "Calculator.0",
+      "Out",
+      "Average0D.3",
+      "In"
+    ],
+    [
+      "ebeamh:raw:ebeamPhotonEnergy",
+      "Out",
+      "ScatterPlot.1",
+      "X"
+    ],
+    [
+      "feespec:raw:integral",
+      "Out",
+      "ScatterPlot.1",
+      "Y"
+    ],
+    [
+      "MfxDg1BmMon:raw:totalIntensityJoules",
+      "Out",
+      "Average0D.1",
+      "In"
+    ],
+    [
+      "RoiArch.0",
+      "AProj",
+      "Sum.0",
+      "In"
+    ],
+    [
+      "RoiArch.0",
+      "AProj",
+      "PythonEditor.0",
+      "In"
+    ],
+    [
+      "Average1D.0",
+      "Out",
+      "WaveformViewer.0",
+      "In"
+    ],
+    [
+      "Average0D.1",
+      "Out",
+      "ScatterPlot.2",
+      "Y"
+    ],
+    [
+      "Average0D.3",
+      "Out",
+      "ScalarPlot.1",
+      "Y"
+    ],
+    [
+      "Sum.0",
+      "Out",
+      "ScatterPlot.0",
+      "Y"
+    ],
+    [
+      "MfxDg2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "ScatterPlot.0",
+      "X"
+    ],
+    [
+      "MfxDg2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "Average0D.2",
+      "In"
+    ],
+    [
+      "HxxDg1BmMon:raw:totalIntensityJoules",
+      "Out",
+      "Average0D.0",
+      "In"
+    ],
+    [
+      "Average0D.0",
+      "Out",
+      "ScatterPlot.4",
+      "Y"
+    ],
+    [
+      "Average0D.2",
+      "Out",
+      "ScatterPlot.3",
+      "Y"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "ScalarPlot.0",
+      "Y"
+    ]
+  ],
+  "viewbox": {
+    "comments": [
+      {
+        "id": 0,
+        "text": "Thresholder",
+        "topLeft": [
+          1200.0,
+          400.0
+        ],
+        "bottomRight": [
+          1300.0,
+          500.0
+        ]
+      },
+      {
+        "id": 1,
+        "text": "Projections",
+        "topLeft": [
+          1200.0,
+          300.0
+        ],
+        "bottomRight": [
+          1500.0,
+          500.0
+        ]
+      },
+      {
+        "id": 2,
+        "text": "Projections",
+        "topLeft": [
+          700.0,
+          300.0
+        ],
+        "bottomRight": [
+          1000.0,
+          700.0
+        ]
+      },
+      {
+        "id": 3,
+        "text": "Enter comment here",
+        "topLeft": [
+          1400.0,
+          300.0
+        ],
+        "bottomRight": [
+          1500.0,
+          800.0
+        ]
+      },
+      {
+        "id": 4,
+        "text": "Enter comment here",
+        "topLeft": [
+          1300.0,
+          300.0
+        ],
+        "bottomRight": [
+          1400.0,
+          600.0
+        ]
+      },
+      {
+        "id": 5,
+        "text": "Trash Area for Comment Boxes",
+        "topLeft": [
+          1100.0,
+          200.0
+        ],
+        "bottomRight": [
+          1600.0,
+          900.0
+        ]
+      },
+      {
+        "id": 6,
+        "text": "keV Thresholder",
+        "topLeft": [
+          100.0,
+          300.0
+        ],
+        "bottomRight": [
+          400.0,
+          600.0
+        ]
+      }
+    ]
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": []
+  }
+}

--- a/tests/graphs/XAS_HSD.fc
+++ b/tests/graphs/XAS_HSD.fc
@@ -1,0 +1,2084 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "q_atmopal:raw:image",
+      "state": {
+        "pos": [
+          -300.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -553.3953889261161,
+                553.3953889261161
+              ],
+              [
+                -550.1622268159965,
+                550.1622268159965
+              ]
+            ],
+            "viewRange": [
+              [
+                -553.3953889261161,
+                553.3953889261161
+              ],
+              [
+                -550.1622268159965,
+                550.1622268159965
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.3333,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6666,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              29.692358441368434,
+              72.0
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000000000000031f0000031f00000000000000000000031f0000031f00000000000000000c0000000000000000000000031f0000031f",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "step_value",
+      "state": {
+        "pos": [
+          0.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "int",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "mono_ev",
+      "state": {
+        "pos": [
+          0.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "rix_fim1:raw:raw_7",
+      "state": {
+        "pos": [
+          0.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "rix_fim1:raw:raw_7"
+          },
+          "legend": {
+            "trace.0": [
+              "rix_fim1:raw:raw_7",
+              "rix_fim1:raw:raw_7",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -9.919981578209583,
+                264.91998157820956
+              ],
+              [
+                33174.67706137687,
+                33434.32293862313
+              ]
+            ],
+            "viewRange": [
+              [
+                -9.919981578209583,
+                264.91998157820956
+              ],
+              [
+                33174.67706137687,
+                33434.32293862313
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000005a00001126000003790000146a0000005a0000114b000003790000146a00000000000000000f000000005a0000114b000003790000146a",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "hsd:raw:waveforms",
+      "state": {
+        "pos": [
+          0.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "dict",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.0",
+      "state": {
+        "pos": [
+          200.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\nroi = []\ndef func(waveforms):\n    \n    \n    return waveforms[3][0].astype(np.float32)"
+        },
+        "geometry": "01d9d0cb00030000000007a30000120c00000ac200001549000007a30000122a00000ac20000154900000000000000000c00000007a30000122a00000ac200001549"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.4",
+      "state": {
+        "pos": [
+          200.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\n\ndef func(E):\n    return np.around(E,1).astype(np.float32)"
+        },
+        "geometry": "01d9d0cb000300000000006b000001690000038a000004ad0000006b0000018e0000038a000004ad00000000000000000d700000006b0000018e0000038a000004ad"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.5",
+      "state": {
+        "pos": [
+          200.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\n\ndef func(wf):\n    return np.array(wf).astype(np.float32)"
+        },
+        "geometry": "01d9d0cb00030000000000000000001b0000031f0000035f00000000000000400000031f0000035f00000000000000000d7000000000000000400000031f0000035f"
+      }
+    },
+    {
+      "class": "Average1D",
+      "name": "Average1D.0",
+      "state": {
+        "pos": [
+          400.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 100,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb000300000000002d000000480000034c0000038c0000002d0000006d0000034c0000038c00000000000000000d700000002d0000006d0000034c0000038c"
+      }
+    },
+    {
+      "class": "Average1D",
+      "name": "Average1D.1",
+      "state": {
+        "pos": [
+          400.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 100,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb00030000000007ed0000008d00000b0c000003d1000007ed000000b200000b0c000003d100000000000000000d70000007ed000000b200000b0c000003d1"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.0",
+      "state": {
+        "pos": [
+          400.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 100,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb000300000000005a0000007500000379000003b90000005a0000009a00000379000003b900000000000000000d700000005a0000009a00000379000003b9"
+      }
+    },
+    {
+      "class": "ScalarViewer",
+      "name": "ScalarViewer.2",
+      "state": {
+        "pos": [
+          400.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb00030000000005ce000013b1000007080000143d000005ce000013b1000007080000143d00000000000000000c00000005ce000013b1000007080000143d"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.1",
+      "state": {
+        "pos": [
+          400.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.0.Out",
+              "PythonEditor.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -453.78411722838155,
+                12332.784117228382
+              ],
+              [
+                1914.1733421970266,
+                2172.219593500561
+              ]
+            ],
+            "viewRange": [
+              [
+                -453.78411722838155,
+                12332.784117228382
+              ],
+              [
+                1914.1733421970266,
+                2172.219593500561
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000110000000a860000141f00000da50000110000000a860000141f00000da500000001000000000c000000110000000a860000141f00000da5"
+      }
+    },
+    {
+      "class": "Roi1D",
+      "name": "Roi1D.0",
+      "state": {
+        "pos": [
+          600.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "origin": 4750,
+          "extent": 5050
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Average1D.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Average1D.0.Out",
+              "Average1D.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                3674.1752450869585,
+                5641.397937720229
+              ],
+              [
+                2024.3137550277452,
+                2140.2024901806894
+              ]
+            ],
+            "viewRange": [
+              [
+                3674.1752450869585,
+                5641.397937720229
+              ],
+              [
+                2024.3137550277452,
+                2140.2024901806894
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000053d000010fc0000085c000014390000053d0000111a0000085c0000143900000000000000000c000000053d0000111a0000085c00001439"
+      }
+    },
+    {
+      "class": "Roi1D",
+      "name": "Roi1D.1",
+      "state": {
+        "pos": [
+          600.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "origin": 80,
+          "extent": 160
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Average1D.1.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Average1D.1.Out",
+              "Average1D.1.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -11.166264788459694,
+                266.16626478845967
+              ],
+              [
+                32316.08412874725,
+                33823.78696500274
+              ]
+            ],
+            "viewRange": [
+              [
+                -11.166264788459694,
+                266.16626478845967
+              ],
+              [
+                32316.08412874725,
+                33823.78696500274
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000007970000016000000ab6000004a4000007970000018500000ab6000004a400000000000000000d70000007970000018500000ab6000004a4"
+      }
+    },
+    {
+      "class": "ScalarViewer",
+      "name": "ScalarViewer.3",
+      "state": {
+        "pos": [
+          600.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb000300000000071f000013b10000089c000014350000071f000013b10000089c0000143500000000000000000c000000071f000013b10000089c00001435"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.0",
+      "state": {
+        "pos": [
+          800.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Roi1D.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Roi1D.0.Out",
+              "Roi1D.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -11.550871476963383,
+                310.5508714769634
+              ],
+              [
+                2002.393900933322,
+                2057.986103949491
+              ]
+            ],
+            "viewRange": [
+              [
+                -11.550871476963383,
+                310.5508714769634
+              ],
+              [
+                2002.393900933322,
+                2057.986103949491
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000009f8000001ad00000d17000004cc000009f8000001ad00000d17000004cc00000004000000000c00000009f8000001ad00000d17000004cc"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.1",
+      "state": {
+        "pos": [
+          800.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\n# from scipy.optimize import curve_fit\n# from scipy.signal import find_peaks\n\n# N = 21\n\ndef func(wf):\n    wf = -wf + wf[:50].mean()\n    # L = len(wf)\n    # cutoff = int((N-1)/2)\n    # x = np.arange(L)\n    # x = x[cutoff:-cutoff]\n\n    # awf = np.convolve(wf,np.ones(N)/N,mode='valid')\n    # peaks, _ = find_peaks(awf[::-1],height=1.2)\n    # x0 = len(x)-peaks[0]\n    # I = wf[x0-50+cutoff:x0+50+cutoff].mean()\n    \n    return wf[195:245].mean()"
+        },
+        "geometry": "01d9d0cb00030000000005280000143d000008470000177a000005280000145b000008470000177a00000000000000000c00000005280000145b000008470000177a"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.2",
+      "state": {
+        "pos": [
+          800.0,
+          -100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Roi1D.1.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Roi1D.1.Out",
+              "Roi1D.1.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -3.073249194817871,
+                82.07324919481788
+              ],
+              [
+                33144.64204716515,
+                33462.1121779146
+              ]
+            ],
+            "viewRange": [
+              [
+                -3.073249194817871,
+                82.07324919481788
+              ],
+              [
+                33144.64204716515,
+                33462.1121779146
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000009f80000039f00000d17000006be000009f80000039f00000d17000006be00000004000000000c00000009f80000039f00000d17000006be"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.2",
+      "state": {
+        "pos": [
+          800.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "def func(wf):\n    wf = -wf+wf[:20].mean()\n    wf[wf<0]=0\n    return wf[30:].mean()"
+        },
+        "geometry": "01d9d0cb0003000000000664000000ec00000983000004300000066400000111000009830000043000000000000000000d7000000664000001110000098300000430"
+      }
+    },
+    {
+      "class": "ScalarViewer",
+      "name": "ScalarViewer.0",
+      "state": {
+        "pos": [
+          1000.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb00030000000000000000001b0000031f0000035f00000000000000400000031f0000035f00000000000000000d7000000000000000400000031f0000035f"
+      }
+    },
+    {
+      "class": "ScalarViewer",
+      "name": "ScalarViewer.1",
+      "state": {
+        "pos": [
+          1000.0,
+          -100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb00030000000000000000001b0000031f0000035f00000000000000400000031f0000035f00000000000000000d7000000000000000400000031f0000035f"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.0",
+      "state": {
+        "pos": [
+          1000.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 10000,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.1.Out vs PythonEditor.2.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.1.Out vs PythonEditor.2.Out",
+              "PythonEditor.1.Out vs PythonEditor.2.Out",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "Size": 6
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                0.3421640086651545,
+                0.716742248487403
+              ],
+              [
+                0.7916963358236234,
+                1.2840056161569675
+              ]
+            ],
+            "viewRange": [
+              [
+                0.3421640086651545,
+                0.716742248487403
+              ],
+              [
+                0.7916963358236234,
+                1.2840056161569675
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000f77000001ab000012a2000004ca00000f77000001ab000012a2000004ca00000004000000000c0000000f77000001ab000012a2000004ca"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.3",
+      "state": {
+        "pos": [
+          1100.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "def func(I0,I):\n    return I/I0"
+        },
+        "geometry": "01d9d0cb000300000000002d000000480000034c0000038c0000002d0000006d0000034c0000038c00000000000000000d700000002d0000006d0000034c0000038c"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.0",
+      "state": {
+        "pos": [
+          1400.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.0",
+      "state": {
+        "pos": [
+          1600.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "TFY"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              "TFY",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 16
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                527.5250617314312,
+                537.6757976435688
+              ],
+              [
+                1.5210088198800782,
+                2.1530484253744384
+              ]
+            ],
+            "viewRange": [
+              [
+                527.5250617314312,
+                537.6757976435688
+              ],
+              [
+                1.5210088198800782,
+                2.1530484253744384
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000000000000087000000bff00000f2f0000014400000a3d00000bfe00000f2e00000002020000000c00000000000000088e00000bff00000f2f"
+      }
+    }
+  ],
+  "connects": [
+    [
+      "mono_ev",
+      "Out",
+      "PythonEditor.4",
+      "In"
+    ],
+    [
+      "rix_fim1:raw:raw_7",
+      "Out",
+      "PythonEditor.5",
+      "In"
+    ],
+    [
+      "hsd:raw:waveforms",
+      "Out",
+      "PythonEditor.0",
+      "In"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "Average1D.0",
+      "In"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "WaveformViewer.1",
+      "In"
+    ],
+    [
+      "PythonEditor.4",
+      "Out",
+      "Average0D.0",
+      "In"
+    ],
+    [
+      "PythonEditor.4",
+      "Out",
+      "ScalarViewer.2",
+      "In"
+    ],
+    [
+      "PythonEditor.5",
+      "Out",
+      "Average1D.1",
+      "In"
+    ],
+    [
+      "Average1D.0",
+      "Out",
+      "Roi1D.0",
+      "In"
+    ],
+    [
+      "Average1D.1",
+      "Out",
+      "Roi1D.1",
+      "In"
+    ],
+    [
+      "Average0D.0",
+      "Out",
+      "MeanVsScan.0",
+      "Bin"
+    ],
+    [
+      "Average0D.0",
+      "Out",
+      "ScalarViewer.3",
+      "In"
+    ],
+    [
+      "Roi1D.0",
+      "Out",
+      "WaveformViewer.0",
+      "In"
+    ],
+    [
+      "Roi1D.0",
+      "Out",
+      "PythonEditor.1",
+      "In"
+    ],
+    [
+      "Roi1D.1",
+      "Out",
+      "WaveformViewer.2",
+      "In"
+    ],
+    [
+      "Roi1D.1",
+      "Out",
+      "PythonEditor.2",
+      "In"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "ScalarViewer.0",
+      "In"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "ScatterPlot.0",
+      "Y"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "PythonEditor.3",
+      "In.1"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "ScalarViewer.1",
+      "In"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "ScatterPlot.0",
+      "X"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "PythonEditor.3",
+      "In"
+    ],
+    [
+      "PythonEditor.3",
+      "Out",
+      "MeanVsScan.0",
+      "Value"
+    ],
+    [
+      "MeanVsScan.0",
+      "Bins",
+      "LinePlot.0",
+      "X"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts",
+      "LinePlot.0",
+      "Y"
+    ]
+  ],
+  "viewbox": {
+    "comments": [
+      {
+        "id": 8,
+        "text": "Use source\nchannel",
+        "topLeft": [
+          0.0,
+          -300.0
+        ],
+        "bottomRight": [
+          100.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 9,
+        "text": "Average the \nregions with \nand without \nsignal",
+        "topLeft": [
+          400.0,
+          -300.0
+        ],
+        "bottomRight": [
+          500.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 10,
+        "text": "Integrate \naround \nsignal",
+        "topLeft": [
+          200.0,
+          -300.0
+        ],
+        "bottomRight": [
+          300.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 11,
+        "text": "Signal - Background",
+        "topLeft": [
+          600.0,
+          -300.0
+        ],
+        "bottomRight": [
+          700.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 12,
+        "text": "Signal channel",
+        "topLeft": [
+          0.0,
+          200.0
+        ],
+        "bottomRight": [
+          100.0,
+          300.0
+        ]
+      },
+      {
+        "id": 15,
+        "text": "Pre IP (NORM)",
+        "topLeft": [
+          0.0,
+          -100.0
+        ],
+        "bottomRight": [
+          100.0,
+          0.0
+        ]
+      },
+      {
+        "id": 20,
+        "text": "INTEGRATION",
+        "topLeft": [
+          1500.0,
+          0.0
+        ],
+        "bottomRight": [
+          1600.0,
+          1200.0
+        ]
+      },
+      {
+        "id": 17,
+        "text": "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nIO ",
+        "topLeft": [
+          0.0,
+          600.0
+        ],
+        "bottomRight": [
+          700.0,
+          900.0
+        ]
+      },
+      {
+        "id": 18,
+        "text": "\n\n\n\nAPD SIGNAL",
+        "topLeft": [
+          0.0,
+          200.0
+        ],
+        "bottomRight": [
+          700.0,
+          500.0
+        ]
+      }
+    ]
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": []
+  }
+}

--- a/tests/graphs/fine_timing_scan_goose_run25_ls.fc
+++ b/tests/graphs/fine_timing_scan_goose_run25_ls.fc
@@ -1,0 +1,2295 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "timing:raw:eventcodes",
+      "state": {
+        "pos": [
+          200.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "timing:raw:eventcodes"
+          },
+          "legend": {
+            "trace.0": [
+              "timing:raw:eventcodes",
+              "timing:raw:eventcodes",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                73.65711453139853,
+                82.39844531006136
+              ],
+              [
+                -3.555446009790865,
+                1.1990898417921991
+              ]
+            ],
+            "viewRange": [
+              [
+                73.65711453139853,
+                82.39844531006136
+              ],
+              [
+                -3.555446009790865,
+                1.1990898417921991
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000001300001112000003320000144b0000001300001130000003320000144b00000000000000000c000000001300001130000003320000144b",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "hsd:raw:waveforms:1:0",
+      "state": {
+        "pos": [
+          200.0,
+          1200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "hsd:raw:waveforms:1:0"
+          },
+          "legend": {
+            "trace.0": [
+              "hsd:raw:waveforms:1:0",
+              "hsd:raw:waveforms:1:0",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -458.9056932269165,
+                12337.905693226918
+              ],
+              [
+                2042.3810497179663,
+                2059.618950282034
+              ]
+            ],
+            "viewRange": [
+              [
+                -458.9056932269165,
+                12337.905693226918
+              ],
+              [
+                2042.3810497179663,
+                2059.618950282034
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000000000000110c0000031f00001449000000000000112a0000031f0000144900000000000000000c00000000000000112a0000031f00001449",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "hsd:raw:waveforms:0:0",
+      "state": {
+        "pos": [
+          200.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "hsd:raw:waveforms:0:0"
+          },
+          "legend": {
+            "trace.0": [
+              "hsd:raw:waveforms:0:0",
+              "hsd:raw:waveforms:0:0",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -34.98237581462083,
+                1057.9823758146208
+              ],
+              [
+                1.7685321404800916,
+                8.901531846187224
+              ]
+            ],
+            "viewRange": [
+              [
+                -34.98237581462083,
+                1057.9823758146208
+              ],
+              [
+                1.7685321404800916,
+                8.901531846187224
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000000000000448000003c0000005a80000000100000449000003bf000005a700000000000000000f000000000100000449000003bf000005a7",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "Roi1D",
+      "name": "Roi1D.0",
+      "state": {
+        "pos": [
+          400.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "origin": 174,
+          "extent": 496
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "hsd:raw:waveforms:3:0"
+          },
+          "legend": {
+            "trace.0": [
+              "hsd:raw:waveforms:0:0",
+              "hsd:raw:waveforms:3:0",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -38.726505615470934,
+                1061.7265056154708
+              ],
+              [
+                1.375481056268593,
+                8.326580445754503
+              ]
+            ],
+            "viewRange": [
+              [
+                -38.726505615470934,
+                1061.7265056154708
+              ],
+              [
+                1.375481056268593,
+                8.326580445754503
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000005a8000003c00000070800000001000005a9000003bf0000070700000000000000000f0000000001000005a9000003bf00000707"
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "step_value",
+      "state": {
+        "pos": [
+          400.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "int",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000010fc0000031f00001439000000000000111a0000031f0000143900000000000000000c00000000000000111a0000031f00001439",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "Average1D",
+      "name": "Average1D.0",
+      "state": {
+        "pos": [
+          400.0,
+          1200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 100,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb000300000000003e000011410000035d000014870000003e000011680000035d0000148700000000000000000f000000003e000011680000035d00001487"
+      }
+    },
+    {
+      "class": "Take",
+      "name": "Take.0",
+      "state": {
+        "pos": [
+          500.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[amitypes.array.Array3d, amitypes.array.Array2d, amitypes.array.Array1d, list[float], tuple[float]]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "axis": 0,
+          "index": 272,
+          "mode": "raise"
+        },
+        "geometry": "01d9d0cb00030000000011cb00001379000014ea000016b6000011cb00001397000014ea000016b600000003000000000c00000011cb00001397000014ea000016b6"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.0",
+      "state": {
+        "pos": [
+          500.0,
+          1000.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "timing:raw:eventcodes"
+          },
+          "legend": {
+            "trace.0": [
+              "timing:raw:eventcodes",
+              "timing:raw:eventcodes",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                250.83196280101686,
+                271.44265038912727
+              ],
+              [
+                -2.002187401903387,
+                1.5326927529395498
+              ]
+            ],
+            "viewRange": [
+              [
+                250.83196280101686,
+                271.44265038912727
+              ],
+              [
+                -2.002187401903387,
+                1.5326927529395498
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000fce0000154f00001c180000189500000fce0000157600001c180000189500000003000000000f0000000fce0000157600001c1800001895"
+      }
+    },
+    {
+      "class": "Average",
+      "name": "Average.0",
+      "state": {
+        "pos": [
+          600.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[amitypes.array.Array1d, amitypes.array.Array2d]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "axis": 0
+        },
+        "geometry": "01d9d0cb00030000000000ee000011da0000040d00001517000000ee000011f80000040d0000151700000000000000000c00000000ee000011f80000040d00001517"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.1",
+      "state": {
+        "pos": [
+          600.0,
+          1200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Average1D.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Average1D.0.Out",
+              "Average1D.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "annotations": {
+            "LineEditor.0": {
+              "name": "",
+              "From": {
+                "X": 4384.0,
+                "Y": 0.0
+              },
+              "To": {
+                "X": 4384.0,
+                "Y": 600.0
+              },
+              "Point": {
+                "symbol": "o",
+                "Brush": [
+                  0,
+                  0,
+                  255,
+                  255
+                ],
+                "Size": 14
+              },
+              "Line": {
+                "color": [
+                  128,
+                  128,
+                  128,
+                  255
+                ],
+                "width": 1,
+                "style": "Solid"
+              }
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -151.19299624630207,
+                4535.192996246302
+              ],
+              [
+                -38.2776763732667,
+                638.2776763732667
+              ]
+            ],
+            "viewRange": [
+              [
+                -151.19299624630207,
+                4535.192996246302
+              ],
+              [
+                -38.2776763732667,
+                638.2776763732667
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000002e8000002800000044800000001000002e90000027f0000044700000000000000000f0000000001000002e90000027f00000447"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.2",
+      "state": {
+        "pos": [
+          900.0,
+          700.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Laser_On": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Event": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "global Out, Event\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, In, Laser_On, *args, **kwargs):\n        \n        if Laser_On == 1:\n            Out = In\n            Event = 1          \n        else:\n            Out = None\n            Event = None  \n\n        # return 1 output(s)\n        return Out, Event"
+        },
+        "geometry": "01d9d0cb00030000000005d10000143d000008f00000177a000005d10000145b000008f00000177a00000000000000000c00000005d10000145b000008f00000177a"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.3",
+      "state": {
+        "pos": [
+          900.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Laser_On": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Event": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "global Out, Event\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, In, Laser_On, *args, **kwargs):\n        \n        if Laser_On == 0:\n            Out = In\n            Event = 1          \n        else:\n            Out = None\n            Event = None\n\n        # return 1 output(s)\n        return Out, Event"
+        },
+        "geometry": "01d9d0cb00030000000003570000143d000006760000177a000003570000145b000006760000177a00000000000000000c00000003570000145b000006760000177a"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.1",
+      "state": {
+        "pos": [
+          1100.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        },
+        "geometry": "01d9d0cb000300000000007a0000118300000399000014c00000007a000011a100000399000014c000000000000000000c000000007a000011a100000399000014c0"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.0",
+      "state": {
+        "pos": [
+          1100.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        },
+        "geometry": "01d9d0cb000300000000039c00001222000006bb0000155f0000039c00001240000006bb0000155f00000000000000000c000000039c00001240000006bb0000155f"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.2",
+      "state": {
+        "pos": [
+          1100.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.3",
+      "state": {
+        "pos": [
+          1100.0,
+          1000.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.0",
+      "state": {
+        "pos": [
+          1400.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "X.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          },
+          "Y.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+            "trace.1": "MeanVsScan.0.Counts vs MeanVsScan.0.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+              "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ],
+            "trace.1": [
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    0,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -3.583313035867099,
+                102.58331303586709
+              ],
+              [
+                4.864091180419253,
+                5.115987999227412
+              ]
+            ],
+            "viewRange": [
+              [
+                -3.583313035867099,
+                102.58331303586709
+              ],
+              [
+                4.864091180419253,
+                5.115987999227412
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000002e8000003c00000044800000001000002e9000003bf0000044700000000000000000f0000000001000002e9000003bf00000447"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.2",
+      "state": {
+        "pos": [
+          1400.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "X.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          },
+          "Y.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "MeanVsScan.2.Counts vs MeanVsScan.2.Bins",
+            "trace.1": "MeanVsScan.3.Counts vs MeanVsScan.3.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.2.Counts vs MeanVsScan.2.Bins",
+              "MeanVsScan.2.Counts vs MeanVsScan.2.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ],
+            "trace.1": [
+              "MeanVsScan.3.Counts vs MeanVsScan.3.Bins",
+              "MeanVsScan.3.Counts vs MeanVsScan.3.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                0.30869763814390316,
+                19.6913023618561
+              ],
+              [
+                0.5,
+                1.5
+              ]
+            ],
+            "viewRange": [
+              [
+                0.30869763814390316,
+                19.6913023618561
+              ],
+              [
+                0.5,
+                1.5
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb000300000000090f000015c500000c2e0000190b0000090f000015ec00000c2e0000190b00000000000000000f000000090f000015ec00000c2e0000190b"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.0",
+      "state": {
+        "pos": [
+          1500.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.2": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out.1": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "\ndef func(x,y1,y2):\n    if not (x.shape == y1.shape == y2.shape): \n        min_len = min(len(x), len(y1), len(y2))\n        x = x[:min_len]\n        y1 = y1[:min_len]\n        y2 = y2[:min_len]\n        return x, y1/y2\n    else:\n        return x,y1/y2"
+        },
+        "geometry": "01d9d0cb000300000000055a0000120e000008790000154b0000055a0000122c000008790000154b00000000000000000c000000055a0000122c000008790000154b"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.1",
+      "state": {
+        "pos": [
+          1700.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "PythonEditor.0.Out.1 vs PythonEditor.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.0.Out.1 vs PythonEditor.0.Out",
+              "PythonEditor.0.Out.1 vs PythonEditor.0.Out",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -3.583313035867099,
+                102.58331303586709
+              ],
+              [
+                0.9716799498442887,
+                1.0403090990312962
+              ]
+            ],
+            "viewRange": [
+              [
+                -3.583313035867099,
+                102.58331303586709
+              ],
+              [
+                0.9716799498442887,
+                1.0403090990312962
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000003c00000044800000780000005a8000003c1000004490000077f000005a700000000000000000f00000003c1000004490000077f000005a7"
+      }
+    }
+  ],
+  "connects": [
+    [
+      "timing:raw:eventcodes",
+      "Out",
+      "Take.0",
+      "In"
+    ],
+    [
+      "timing:raw:eventcodes",
+      "Out",
+      "WaveformViewer.0",
+      "In"
+    ],
+    [
+      "hsd:raw:waveforms:1:0",
+      "Out",
+      "Average1D.0",
+      "In"
+    ],
+    [
+      "hsd:raw:waveforms:0:0",
+      "Out",
+      "Roi1D.0",
+      "In"
+    ],
+    [
+      "Roi1D.0",
+      "Out",
+      "Average.0",
+      "In"
+    ],
+    [
+      "step_value",
+      "Out",
+      "MeanVsScan.1",
+      "Bin"
+    ],
+    [
+      "step_value",
+      "Out",
+      "MeanVsScan.0",
+      "Bin"
+    ],
+    [
+      "step_value",
+      "Out",
+      "MeanVsScan.2",
+      "Bin"
+    ],
+    [
+      "step_value",
+      "Out",
+      "MeanVsScan.3",
+      "Bin"
+    ],
+    [
+      "Average1D.0",
+      "Out",
+      "WaveformViewer.1",
+      "In"
+    ],
+    [
+      "Take.0",
+      "Out",
+      "PythonEditor.2",
+      "Laser_On"
+    ],
+    [
+      "Take.0",
+      "Out",
+      "PythonEditor.3",
+      "Laser_On"
+    ],
+    [
+      "Average.0",
+      "Out",
+      "PythonEditor.2",
+      "In"
+    ],
+    [
+      "Average.0",
+      "Out",
+      "PythonEditor.3",
+      "In"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "MeanVsScan.0",
+      "Value"
+    ],
+    [
+      "PythonEditor.2",
+      "Event",
+      "MeanVsScan.3",
+      "Value"
+    ],
+    [
+      "PythonEditor.3",
+      "Out",
+      "MeanVsScan.1",
+      "Value"
+    ],
+    [
+      "PythonEditor.3",
+      "Event",
+      "MeanVsScan.2",
+      "Value"
+    ],
+    [
+      "MeanVsScan.1",
+      "Counts",
+      "LinePlot.0",
+      "Y"
+    ],
+    [
+      "MeanVsScan.1",
+      "Bins",
+      "LinePlot.0",
+      "X"
+    ],
+    [
+      "MeanVsScan.1",
+      "Bins",
+      "PythonEditor.0",
+      "In"
+    ],
+    [
+      "MeanVsScan.1",
+      "Counts",
+      "PythonEditor.0",
+      "In.1"
+    ],
+    [
+      "MeanVsScan.0",
+      "Bins",
+      "LinePlot.0",
+      "X.1"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts",
+      "LinePlot.0",
+      "Y.1"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts",
+      "PythonEditor.0",
+      "In.2"
+    ],
+    [
+      "MeanVsScan.2",
+      "Bins",
+      "LinePlot.2",
+      "X"
+    ],
+    [
+      "MeanVsScan.2",
+      "Counts",
+      "LinePlot.2",
+      "Y"
+    ],
+    [
+      "MeanVsScan.3",
+      "Bins",
+      "LinePlot.2",
+      "X.1"
+    ],
+    [
+      "MeanVsScan.3",
+      "Counts",
+      "LinePlot.2",
+      "Y.1"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "LinePlot.1",
+      "X"
+    ],
+    [
+      "PythonEditor.0",
+      "Out.1",
+      "LinePlot.1",
+      "Y"
+    ]
+  ],
+  "viewbox": {
+    "comments": [
+      {
+        "id": 8,
+        "text": "Use source\nchannel",
+        "topLeft": [
+          0.0,
+          -300.0
+        ],
+        "bottomRight": [
+          100.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 9,
+        "text": "Average the \nregions with \nand without \nsignal",
+        "topLeft": [
+          400.0,
+          -300.0
+        ],
+        "bottomRight": [
+          500.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 10,
+        "text": "Integrate \naround \nsignal",
+        "topLeft": [
+          200.0,
+          -300.0
+        ],
+        "bottomRight": [
+          300.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 11,
+        "text": "Signal - Background",
+        "topLeft": [
+          600.0,
+          -300.0
+        ],
+        "bottomRight": [
+          700.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 12,
+        "text": "Signal channel",
+        "topLeft": [
+          0.0,
+          200.0
+        ],
+        "bottomRight": [
+          100.0,
+          300.0
+        ]
+      },
+      {
+        "id": 15,
+        "text": "Pre IP (NORM)",
+        "topLeft": [
+          0.0,
+          -100.0
+        ],
+        "bottomRight": [
+          100.0,
+          0.0
+        ]
+      },
+      {
+        "id": 20,
+        "text": "INTEGRATION",
+        "topLeft": [
+          1500.0,
+          0.0
+        ],
+        "bottomRight": [
+          1600.0,
+          1200.0
+        ]
+      },
+      {
+        "id": 17,
+        "text": "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nIO ",
+        "topLeft": [
+          0.0,
+          600.0
+        ],
+        "bottomRight": [
+          700.0,
+          900.0
+        ]
+      },
+      {
+        "id": 18,
+        "text": "\n\n\n\nAPD SIGNAL",
+        "topLeft": [
+          0.0,
+          400.0
+        ],
+        "bottomRight": [
+          700.0,
+          700.0
+        ]
+      },
+      {
+        "id": 1,
+        "text": "Signal",
+        "topLeft": [
+          200.0,
+          400.0
+        ],
+        "bottomRight": [
+          300.0,
+          500.0
+        ]
+      },
+      {
+        "id": 2,
+        "text": "BG",
+        "topLeft": [
+          200.0,
+          500.0
+        ],
+        "bottomRight": [
+          300.0,
+          600.0
+        ]
+      },
+      {
+        "id": 3,
+        "text": "Signal",
+        "topLeft": [
+          200.0,
+          600.0
+        ],
+        "bottomRight": [
+          300.0,
+          700.0
+        ]
+      },
+      {
+        "id": 4,
+        "text": "BG",
+        "topLeft": [
+          200.0,
+          700.0
+        ],
+        "bottomRight": [
+          300.0,
+          800.0
+        ]
+      },
+      {
+        "id": 5,
+        "text": "Laser on",
+        "topLeft": [
+          700.0,
+          900.0
+        ],
+        "bottomRight": [
+          800.0,
+          1000.0
+        ]
+      },
+      {
+        "id": 6,
+        "text": "Laser off",
+        "topLeft": [
+          700.0,
+          1000.0
+        ],
+        "bottomRight": [
+          800.0,
+          1100.0
+        ]
+      },
+      {
+        "id": 13,
+        "text": "Off",
+        "topLeft": [
+          800.0,
+          1800.0
+        ],
+        "bottomRight": [
+          900.0,
+          1900.0
+        ]
+      },
+      {
+        "id": 14,
+        "text": "On",
+        "topLeft": [
+          800.0,
+          1600.0
+        ],
+        "bottomRight": [
+          900.0,
+          1700.0
+        ]
+      }
+    ]
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": []
+  }
+}

--- a/tests/graphs/jungfrau_roi_scan.fc
+++ b/tests/graphs/jungfrau_roi_scan.fc
@@ -6142,7 +6142,7 @@
   },
   "library": {
     "paths": [
-      "/sdf/home/x/xppopr/daq/ami_graphs/threshold_detector.py"
+      "tests/graphs/threshold_detector.py"
     ]
   }
 }

--- a/tests/graphs/jungfrau_roi_scan.fc
+++ b/tests/graphs/jungfrau_roi_scan.fc
@@ -1,0 +1,6148 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "jungfrau1M:raw:image",
+      "state": {
+        "pos": [
+          100.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -0.5,
+                0.5
+              ],
+              [
+                -0.5,
+                0.5
+              ]
+            ],
+            "viewRange": [
+              [
+                -0.5,
+                0.5
+              ],
+              [
+                -0.5,
+                0.5
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0,
+              1.0
+            ],
+            "mode": "mono"
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "timestamp",
+      "state": {
+        "pos": [
+          100.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012030000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "XppSb2BmMon:raw:totalIntensityJoules",
+      "state": {
+        "pos": [
+          100.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "ebeamh:raw:ebeamL3Energy",
+      "state": {
+        "pos": [
+          100.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "alvium:raw:value",
+      "state": {
+        "pos": [
+          100.0,
+          1400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -0.5,
+                0.5
+              ],
+              [
+                -0.5,
+                0.5
+              ]
+            ],
+            "viewRange": [
+              [
+                -0.5,
+                0.5
+              ],
+              [
+                -0.5,
+                0.5
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0,
+              1.0
+            ],
+            "mode": "mono"
+          }
+        },
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.0",
+      "state": {
+        "pos": [
+          300.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "from copy import deepcopy\nimport numpy as np\n\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, img, *args, **kwargs):\n        img = deepcopy(img)\n        img[img<5] = 0\n        return img"
+        },
+        "geometry": "01d9d0cb0003000000001225000012ec000015440000152d0000122500001308000015440000152d00000006000000000a000000122500001308000015440000152d"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.1",
+      "state": {
+        "pos": [
+          300.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 120,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012030000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.0",
+      "state": {
+        "pos": [
+          300.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "christmas_tree",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 1000,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "XppSb2BmMon:raw:totalIntensityJoules vs ebeamh:raw:ebeamL3Energy"
+          },
+          "legend": {
+            "trace.0": [
+              "XppSb2BmMon:raw:totalIntensityJoules vs ebeamh:raw:ebeamL3Energy",
+              "XppSb2BmMon:raw:totalIntensityJoules vs ebeamh:raw:ebeamL3Energy",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "Size": 4
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -5.926739200282872,
+                105.9945949843779
+              ],
+              [
+                -9.556485362451502,
+                109.50430237585863
+              ]
+            ],
+            "viewRange": [
+              [
+                -5.926739200282872,
+                105.9945949843779
+              ],
+              [
+                -9.556485362451502,
+                109.50430237585863
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000001e0000004f80000046300000600000001e1000004f900000462000005ff00000000000000000f00000001e1000004f900000462000005ff"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.2",
+      "state": {
+        "pos": [
+          300.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out.1": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "from copy import deepcopy\nimport numpy as np\n\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, img, *args, **kwargs):\n        img = deepcopy(img)\n        h, b = np.histogram(img.ravel(), bins = 1000, range = (-10,50))\n        return b[1:], h"
+        },
+        "geometry": "01d9d0cb00030000000011370000132600001456000016610000113700001342000014560000166100000006000000000a0000001137000013420000145600001661"
+      }
+    },
+    {
+      "class": "ImageViewer",
+      "name": "ImageViewer.3",
+      "state": {
+        "pos": [
+          400.0,
+          1400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -1000.1650166858977,
+                2132.428111208451
+              ],
+              [
+                -423.92925572551053,
+                1522.725404300284
+              ]
+            ],
+            "viewRange": [
+              [
+                -1000.1650166858977,
+                2132.428111208451
+              ],
+              [
+                -423.92925572551053,
+                1522.725404300284
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0,
+              22
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb000300000000081d0000039600000b3c000006d10000081d000003b200000b3c000006d100000003000000000c000000081d000003b200000b3c000006d1"
+      }
+    },
+    {
+      "class": "ImageViewer",
+      "name": "ImageViewer.0",
+      "state": {
+        "pos": [
+          500.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "jf_single_shot",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -59.69866915134344,
+                1042.3681624029625
+              ],
+              [
+                -6.427074940245916,
+                1133.37978624689
+              ]
+            ],
+            "viewRange": [
+              [
+                -59.69866915134344,
+                1042.3681624029625
+              ],
+              [
+                -6.427074940245916,
+                1133.37978624689
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0.005475980770768718,
+              0.3196616694897351
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb00030000000013e3000001cc000017cc0000054e000013e3000001e8000017cc0000054e00000005000000000c00000013e3000001e8000017cc0000054e"
+      }
+    },
+    {
+      "class": "Average2D",
+      "name": "Average2D.0",
+      "state": {
+        "pos": [
+          500.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 2,
+          "infinite": true
+        },
+        "geometry": "01d9d0cb0003000000000ff00000121f0000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e"
+      }
+    },
+    {
+      "class": "Average2D",
+      "name": "Average2D.1",
+      "state": {
+        "pos": [
+          500.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 120,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000d50000013250000106f000014e000000d50000013410000106f000014e000000006000000000a0000000d50000013410000106f000014e0"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.1",
+      "state": {
+        "pos": [
+          500.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "PythonEditor.1",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "from copy import deepcopy\nimport numpy as np\n\nclass EventProcessor():\n\n    def __init__(self):\n        pass\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, img, *args, **kwargs):\n        img = deepcopy(img)\n        img[img<5] = 0\n        #img[img>100] = 0\n        return img"
+        },
+        "geometry": "01d9d0cb00030000000019bc0000125800001cdb000014e3000019bc0000127400001cdb000014e300000001000000000a00000019bc0000127400001cdb000014e3"
+      }
+    },
+    {
+      "class": "TimePlot",
+      "name": "TimePlot.1",
+      "state": {
+        "pos": [
+          500.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "ipm2_time.1",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 1000
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Average0D.1.Out vs timestamp"
+          },
+          "legend": {
+            "trace.0": [
+              "Average0D.1.Out vs timestamp",
+              "Average0D.1.Out vs timestamp",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    30,
+                    225,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1776785446.2548945,
+                1776785468.8151467
+              ],
+              [
+                48.456525851598315,
+                54.6190601683942
+              ]
+            ],
+            "viewRange": [
+              [
+                1776785446.2548945,
+                1776785468.8151467
+              ],
+              [
+                48.456525851598315,
+                54.6190601683942
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -62135596800.0,
+                253370764800.0
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000004f80000033a0000060000000001000004f900000339000005ff00000000000000000f0000000001000004f900000339000005ff"
+      }
+    },
+    {
+      "class": "Average1D",
+      "name": "Average1D.0",
+      "state": {
+        "pos": [
+          500.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 600,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000d160000114f000010350000146e00000d160000114f000010350000146e00000006000000000a0000000d160000114f000010350000146e"
+      }
+    },
+    {
+      "class": "Average1D",
+      "name": "Average1D.1",
+      "state": {
+        "pos": [
+          500.0,
+          -100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 2,
+          "infinite": true
+        },
+        "geometry": "01d9d0cb00030000000010e5000013350000140400001670000010e500001351000014040000167000000006000000000a00000010e5000013510000140400001670"
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "m1_ry",
+      "state": {
+        "pos": [
+          600.0,
+          1200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb0003000000000370000012120000068f0000154d000003700000122e0000068f0000154d00000004000000000a00000003700000122e0000068f0000154d",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "ImageViewer",
+      "name": "ImageViewer.1",
+      "state": {
+        "pos": [
+          700.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "jf_forever",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                245.82004412651736,
+                498.0475778577097
+              ],
+              [
+                603.1135583251025,
+                862.0615259098454
+              ]
+            ],
+            "viewRange": [
+              [
+                245.82004412651736,
+                498.0475778577097
+              ],
+              [
+                603.1135583251025,
+                862.0615259098454
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    48,
+                    18,
+                    59,
+                    255
+                  ]
+                ],
+                [
+                  0.00392156862745098,
+                  [
+                    50,
+                    21,
+                    67,
+                    255
+                  ]
+                ],
+                [
+                  0.00784313725490196,
+                  [
+                    51,
+                    24,
+                    74,
+                    255
+                  ]
+                ],
+                [
+                  0.011764705882352941,
+                  [
+                    52,
+                    27,
+                    81,
+                    255
+                  ]
+                ],
+                [
+                  0.01568627450980392,
+                  [
+                    53,
+                    30,
+                    88,
+                    255
+                  ]
+                ],
+                [
+                  0.0196078431372549,
+                  [
+                    54,
+                    33,
+                    95,
+                    255
+                  ]
+                ],
+                [
+                  0.023529411764705882,
+                  [
+                    55,
+                    36,
+                    102,
+                    255
+                  ]
+                ],
+                [
+                  0.027450980392156862,
+                  [
+                    56,
+                    39,
+                    109,
+                    255
+                  ]
+                ],
+                [
+                  0.03137254901960784,
+                  [
+                    57,
+                    42,
+                    115,
+                    255
+                  ]
+                ],
+                [
+                  0.03529411764705882,
+                  [
+                    58,
+                    45,
+                    121,
+                    255
+                  ]
+                ],
+                [
+                  0.0392156862745098,
+                  [
+                    59,
+                    47,
+                    128,
+                    255
+                  ]
+                ],
+                [
+                  0.043137254901960784,
+                  [
+                    60,
+                    50,
+                    134,
+                    255
+                  ]
+                ],
+                [
+                  0.047058823529411764,
+                  [
+                    61,
+                    53,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.050980392156862744,
+                  [
+                    62,
+                    56,
+                    145,
+                    255
+                  ]
+                ],
+                [
+                  0.054901960784313725,
+                  [
+                    63,
+                    59,
+                    151,
+                    255
+                  ]
+                ],
+                [
+                  0.058823529411764705,
+                  [
+                    63,
+                    62,
+                    156,
+                    255
+                  ]
+                ],
+                [
+                  0.06274509803921569,
+                  [
+                    64,
+                    64,
+                    162,
+                    255
+                  ]
+                ],
+                [
+                  0.06666666666666667,
+                  [
+                    65,
+                    67,
+                    167,
+                    255
+                  ]
+                ],
+                [
+                  0.07058823529411765,
+                  [
+                    65,
+                    70,
+                    172,
+                    255
+                  ]
+                ],
+                [
+                  0.07450980392156863,
+                  [
+                    66,
+                    73,
+                    177,
+                    255
+                  ]
+                ],
+                [
+                  0.0784313725490196,
+                  [
+                    66,
+                    75,
+                    181,
+                    255
+                  ]
+                ],
+                [
+                  0.08235294117647059,
+                  [
+                    67,
+                    78,
+                    186,
+                    255
+                  ]
+                ],
+                [
+                  0.08627450980392157,
+                  [
+                    68,
+                    81,
+                    191,
+                    255
+                  ]
+                ],
+                [
+                  0.09019607843137255,
+                  [
+                    68,
+                    84,
+                    195,
+                    255
+                  ]
+                ],
+                [
+                  0.09411764705882353,
+                  [
+                    68,
+                    86,
+                    199,
+                    255
+                  ]
+                ],
+                [
+                  0.09803921568627451,
+                  [
+                    69,
+                    89,
+                    203,
+                    255
+                  ]
+                ],
+                [
+                  0.10196078431372549,
+                  [
+                    69,
+                    92,
+                    207,
+                    255
+                  ]
+                ],
+                [
+                  0.10588235294117647,
+                  [
+                    69,
+                    94,
+                    211,
+                    255
+                  ]
+                ],
+                [
+                  0.10980392156862745,
+                  [
+                    70,
+                    97,
+                    214,
+                    255
+                  ]
+                ],
+                [
+                  0.11372549019607843,
+                  [
+                    70,
+                    100,
+                    218,
+                    255
+                  ]
+                ],
+                [
+                  0.11764705882352941,
+                  [
+                    70,
+                    102,
+                    221,
+                    255
+                  ]
+                ],
+                [
+                  0.12156862745098039,
+                  [
+                    70,
+                    105,
+                    224,
+                    255
+                  ]
+                ],
+                [
+                  0.12549019607843137,
+                  [
+                    70,
+                    107,
+                    227,
+                    255
+                  ]
+                ],
+                [
+                  0.12941176470588234,
+                  [
+                    71,
+                    110,
+                    230,
+                    255
+                  ]
+                ],
+                [
+                  0.13333333333333333,
+                  [
+                    71,
+                    113,
+                    233,
+                    255
+                  ]
+                ],
+                [
+                  0.13725490196078433,
+                  [
+                    71,
+                    115,
+                    235,
+                    255
+                  ]
+                ],
+                [
+                  0.1411764705882353,
+                  [
+                    71,
+                    118,
+                    238,
+                    255
+                  ]
+                ],
+                [
+                  0.14509803921568626,
+                  [
+                    71,
+                    120,
+                    240,
+                    255
+                  ]
+                ],
+                [
+                  0.14901960784313725,
+                  [
+                    71,
+                    123,
+                    242,
+                    255
+                  ]
+                ],
+                [
+                  0.15294117647058825,
+                  [
+                    70,
+                    125,
+                    244,
+                    255
+                  ]
+                ],
+                [
+                  0.1568627450980392,
+                  [
+                    70,
+                    128,
+                    246,
+                    255
+                  ]
+                ],
+                [
+                  0.16078431372549018,
+                  [
+                    70,
+                    130,
+                    248,
+                    255
+                  ]
+                ],
+                [
+                  0.16470588235294117,
+                  [
+                    70,
+                    133,
+                    250,
+                    255
+                  ]
+                ],
+                [
+                  0.16862745098039217,
+                  [
+                    70,
+                    135,
+                    251,
+                    255
+                  ]
+                ],
+                [
+                  0.17254901960784313,
+                  [
+                    69,
+                    138,
+                    252,
+                    255
+                  ]
+                ],
+                [
+                  0.1764705882352941,
+                  [
+                    69,
+                    140,
+                    253,
+                    255
+                  ]
+                ],
+                [
+                  0.1803921568627451,
+                  [
+                    68,
+                    143,
+                    254,
+                    255
+                  ]
+                ],
+                [
+                  0.1843137254901961,
+                  [
+                    67,
+                    145,
+                    254,
+                    255
+                  ]
+                ],
+                [
+                  0.18823529411764706,
+                  [
+                    66,
+                    148,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0.19215686274509802,
+                  [
+                    65,
+                    150,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0.19607843137254902,
+                  [
+                    64,
+                    153,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0.2,
+                  [
+                    62,
+                    155,
+                    254,
+                    255
+                  ]
+                ],
+                [
+                  0.20392156862745098,
+                  [
+                    61,
+                    158,
+                    254,
+                    255
+                  ]
+                ],
+                [
+                  0.20784313725490194,
+                  [
+                    59,
+                    160,
+                    253,
+                    255
+                  ]
+                ],
+                [
+                  0.21176470588235294,
+                  [
+                    58,
+                    163,
+                    252,
+                    255
+                  ]
+                ],
+                [
+                  0.21568627450980393,
+                  [
+                    56,
+                    165,
+                    251,
+                    255
+                  ]
+                ],
+                [
+                  0.2196078431372549,
+                  [
+                    55,
+                    168,
+                    250,
+                    255
+                  ]
+                ],
+                [
+                  0.22352941176470587,
+                  [
+                    53,
+                    171,
+                    248,
+                    255
+                  ]
+                ],
+                [
+                  0.22745098039215686,
+                  [
+                    51,
+                    173,
+                    247,
+                    255
+                  ]
+                ],
+                [
+                  0.23137254901960785,
+                  [
+                    49,
+                    175,
+                    245,
+                    255
+                  ]
+                ],
+                [
+                  0.23529411764705882,
+                  [
+                    47,
+                    178,
+                    244,
+                    255
+                  ]
+                ],
+                [
+                  0.2392156862745098,
+                  [
+                    46,
+                    180,
+                    242,
+                    255
+                  ]
+                ],
+                [
+                  0.24313725490196078,
+                  [
+                    44,
+                    183,
+                    240,
+                    255
+                  ]
+                ],
+                [
+                  0.24705882352941178,
+                  [
+                    42,
+                    185,
+                    238,
+                    255
+                  ]
+                ],
+                [
+                  0.25098039215686274,
+                  [
+                    40,
+                    188,
+                    235,
+                    255
+                  ]
+                ],
+                [
+                  0.2549019607843137,
+                  [
+                    39,
+                    190,
+                    233,
+                    255
+                  ]
+                ],
+                [
+                  0.2588235294117647,
+                  [
+                    37,
+                    192,
+                    231,
+                    255
+                  ]
+                ],
+                [
+                  0.2627450980392157,
+                  [
+                    35,
+                    195,
+                    228,
+                    255
+                  ]
+                ],
+                [
+                  0.26666666666666666,
+                  [
+                    34,
+                    197,
+                    226,
+                    255
+                  ]
+                ],
+                [
+                  0.27058823529411763,
+                  [
+                    32,
+                    199,
+                    223,
+                    255
+                  ]
+                ],
+                [
+                  0.27450980392156865,
+                  [
+                    31,
+                    201,
+                    221,
+                    255
+                  ]
+                ],
+                [
+                  0.2784313725490196,
+                  [
+                    30,
+                    203,
+                    218,
+                    255
+                  ]
+                ],
+                [
+                  0.2823529411764706,
+                  [
+                    28,
+                    205,
+                    216,
+                    255
+                  ]
+                ],
+                [
+                  0.28627450980392155,
+                  [
+                    27,
+                    208,
+                    213,
+                    255
+                  ]
+                ],
+                [
+                  0.2901960784313725,
+                  [
+                    26,
+                    210,
+                    210,
+                    255
+                  ]
+                ],
+                [
+                  0.29411764705882354,
+                  [
+                    26,
+                    212,
+                    208,
+                    255
+                  ]
+                ],
+                [
+                  0.2980392156862745,
+                  [
+                    25,
+                    213,
+                    205,
+                    255
+                  ]
+                ],
+                [
+                  0.30196078431372547,
+                  [
+                    24,
+                    215,
+                    202,
+                    255
+                  ]
+                ],
+                [
+                  0.3058823529411765,
+                  [
+                    24,
+                    217,
+                    200,
+                    255
+                  ]
+                ],
+                [
+                  0.30980392156862746,
+                  [
+                    24,
+                    219,
+                    197,
+                    255
+                  ]
+                ],
+                [
+                  0.3137254901960784,
+                  [
+                    24,
+                    221,
+                    194,
+                    255
+                  ]
+                ],
+                [
+                  0.3176470588235294,
+                  [
+                    24,
+                    222,
+                    192,
+                    255
+                  ]
+                ],
+                [
+                  0.32156862745098036,
+                  [
+                    24,
+                    224,
+                    189,
+                    255
+                  ]
+                ],
+                [
+                  0.3254901960784314,
+                  [
+                    25,
+                    226,
+                    187,
+                    255
+                  ]
+                ],
+                [
+                  0.32941176470588235,
+                  [
+                    25,
+                    227,
+                    185,
+                    255
+                  ]
+                ],
+                [
+                  0.3333333333333333,
+                  [
+                    26,
+                    228,
+                    182,
+                    255
+                  ]
+                ],
+                [
+                  0.33725490196078434,
+                  [
+                    28,
+                    230,
+                    180,
+                    255
+                  ]
+                ],
+                [
+                  0.3411764705882353,
+                  [
+                    29,
+                    231,
+                    178,
+                    255
+                  ]
+                ],
+                [
+                  0.34509803921568627,
+                  [
+                    31,
+                    233,
+                    175,
+                    255
+                  ]
+                ],
+                [
+                  0.34901960784313724,
+                  [
+                    32,
+                    234,
+                    172,
+                    255
+                  ]
+                ],
+                [
+                  0.3529411764705882,
+                  [
+                    34,
+                    235,
+                    170,
+                    255
+                  ]
+                ],
+                [
+                  0.3568627450980392,
+                  [
+                    37,
+                    236,
+                    167,
+                    255
+                  ]
+                ],
+                [
+                  0.3607843137254902,
+                  [
+                    39,
+                    238,
+                    164,
+                    255
+                  ]
+                ],
+                [
+                  0.36470588235294116,
+                  [
+                    42,
+                    239,
+                    161,
+                    255
+                  ]
+                ],
+                [
+                  0.3686274509803922,
+                  [
+                    44,
+                    240,
+                    158,
+                    255
+                  ]
+                ],
+                [
+                  0.37254901960784315,
+                  [
+                    47,
+                    241,
+                    155,
+                    255
+                  ]
+                ],
+                [
+                  0.3764705882352941,
+                  [
+                    50,
+                    242,
+                    152,
+                    255
+                  ]
+                ],
+                [
+                  0.3803921568627451,
+                  [
+                    53,
+                    243,
+                    148,
+                    255
+                  ]
+                ],
+                [
+                  0.38431372549019605,
+                  [
+                    56,
+                    244,
+                    145,
+                    255
+                  ]
+                ],
+                [
+                  0.38823529411764707,
+                  [
+                    60,
+                    245,
+                    142,
+                    255
+                  ]
+                ],
+                [
+                  0.39215686274509803,
+                  [
+                    63,
+                    246,
+                    138,
+                    255
+                  ]
+                ],
+                [
+                  0.396078431372549,
+                  [
+                    67,
+                    247,
+                    135,
+                    255
+                  ]
+                ],
+                [
+                  0.4,
+                  [
+                    70,
+                    248,
+                    132,
+                    255
+                  ]
+                ],
+                [
+                  0.403921568627451,
+                  [
+                    74,
+                    248,
+                    128,
+                    255
+                  ]
+                ],
+                [
+                  0.40784313725490196,
+                  [
+                    78,
+                    249,
+                    125,
+                    255
+                  ]
+                ],
+                [
+                  0.4117647058823529,
+                  [
+                    82,
+                    250,
+                    122,
+                    255
+                  ]
+                ],
+                [
+                  0.4156862745098039,
+                  [
+                    85,
+                    250,
+                    118,
+                    255
+                  ]
+                ],
+                [
+                  0.4196078431372549,
+                  [
+                    89,
+                    251,
+                    115,
+                    255
+                  ]
+                ],
+                [
+                  0.4235294117647059,
+                  [
+                    93,
+                    252,
+                    111,
+                    255
+                  ]
+                ],
+                [
+                  0.42745098039215684,
+                  [
+                    97,
+                    252,
+                    108,
+                    255
+                  ]
+                ],
+                [
+                  0.43137254901960786,
+                  [
+                    101,
+                    253,
+                    105,
+                    255
+                  ]
+                ],
+                [
+                  0.43529411764705883,
+                  [
+                    105,
+                    253,
+                    102,
+                    255
+                  ]
+                ],
+                [
+                  0.4392156862745098,
+                  [
+                    109,
+                    254,
+                    98,
+                    255
+                  ]
+                ],
+                [
+                  0.44313725490196076,
+                  [
+                    113,
+                    254,
+                    95,
+                    255
+                  ]
+                ],
+                [
+                  0.44705882352941173,
+                  [
+                    117,
+                    254,
+                    92,
+                    255
+                  ]
+                ],
+                [
+                  0.45098039215686275,
+                  [
+                    121,
+                    254,
+                    89,
+                    255
+                  ]
+                ],
+                [
+                  0.4549019607843137,
+                  [
+                    125,
+                    255,
+                    86,
+                    255
+                  ]
+                ],
+                [
+                  0.4588235294117647,
+                  [
+                    128,
+                    255,
+                    83,
+                    255
+                  ]
+                ],
+                [
+                  0.4627450980392157,
+                  [
+                    132,
+                    255,
+                    81,
+                    255
+                  ]
+                ],
+                [
+                  0.4666666666666667,
+                  [
+                    136,
+                    255,
+                    78,
+                    255
+                  ]
+                ],
+                [
+                  0.47058823529411764,
+                  [
+                    139,
+                    255,
+                    75,
+                    255
+                  ]
+                ],
+                [
+                  0.4745098039215686,
+                  [
+                    143,
+                    255,
+                    73,
+                    255
+                  ]
+                ],
+                [
+                  0.4784313725490196,
+                  [
+                    146,
+                    255,
+                    71,
+                    255
+                  ]
+                ],
+                [
+                  0.4823529411764706,
+                  [
+                    150,
+                    254,
+                    68,
+                    255
+                  ]
+                ],
+                [
+                  0.48627450980392156,
+                  [
+                    153,
+                    254,
+                    66,
+                    255
+                  ]
+                ],
+                [
+                  0.49019607843137253,
+                  [
+                    156,
+                    254,
+                    64,
+                    255
+                  ]
+                ],
+                [
+                  0.49411764705882355,
+                  [
+                    159,
+                    253,
+                    63,
+                    255
+                  ]
+                ],
+                [
+                  0.4980392156862745,
+                  [
+                    161,
+                    253,
+                    61,
+                    255
+                  ]
+                ],
+                [
+                  0.5019607843137255,
+                  [
+                    164,
+                    252,
+                    60,
+                    255
+                  ]
+                ],
+                [
+                  0.5058823529411764,
+                  [
+                    167,
+                    252,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.5098039215686274,
+                  [
+                    169,
+                    251,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.5137254901960784,
+                  [
+                    172,
+                    251,
+                    56,
+                    255
+                  ]
+                ],
+                [
+                  0.5176470588235293,
+                  [
+                    175,
+                    250,
+                    55,
+                    255
+                  ]
+                ],
+                [
+                  0.5215686274509804,
+                  [
+                    177,
+                    249,
+                    54,
+                    255
+                  ]
+                ],
+                [
+                  0.5254901960784314,
+                  [
+                    180,
+                    248,
+                    54,
+                    255
+                  ]
+                ],
+                [
+                  0.5294117647058824,
+                  [
+                    183,
+                    247,
+                    53,
+                    255
+                  ]
+                ],
+                [
+                  0.5333333333333333,
+                  [
+                    185,
+                    246,
+                    53,
+                    255
+                  ]
+                ],
+                [
+                  0.5372549019607843,
+                  [
+                    188,
+                    245,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5411764705882353,
+                  [
+                    190,
+                    244,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5450980392156862,
+                  [
+                    193,
+                    243,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5490196078431373,
+                  [
+                    195,
+                    241,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5529411764705883,
+                  [
+                    198,
+                    240,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5568627450980392,
+                  [
+                    200,
+                    239,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5607843137254902,
+                  [
+                    203,
+                    237,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5647058823529412,
+                  [
+                    205,
+                    236,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5686274509803921,
+                  [
+                    208,
+                    234,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.5725490196078431,
+                  [
+                    210,
+                    233,
+                    53,
+                    255
+                  ]
+                ],
+                [
+                  0.5764705882352941,
+                  [
+                    212,
+                    231,
+                    53,
+                    255
+                  ]
+                ],
+                [
+                  0.580392156862745,
+                  [
+                    215,
+                    229,
+                    53,
+                    255
+                  ]
+                ],
+                [
+                  0.5843137254901961,
+                  [
+                    217,
+                    228,
+                    54,
+                    255
+                  ]
+                ],
+                [
+                  0.5882352941176471,
+                  [
+                    219,
+                    226,
+                    54,
+                    255
+                  ]
+                ],
+                [
+                  0.592156862745098,
+                  [
+                    221,
+                    224,
+                    55,
+                    255
+                  ]
+                ],
+                [
+                  0.596078431372549,
+                  [
+                    223,
+                    223,
+                    55,
+                    255
+                  ]
+                ],
+                [
+                  0.6,
+                  [
+                    225,
+                    221,
+                    55,
+                    255
+                  ]
+                ],
+                [
+                  0.6039215686274509,
+                  [
+                    227,
+                    219,
+                    56,
+                    255
+                  ]
+                ],
+                [
+                  0.6078431372549019,
+                  [
+                    229,
+                    217,
+                    56,
+                    255
+                  ]
+                ],
+                [
+                  0.611764705882353,
+                  [
+                    231,
+                    215,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.615686274509804,
+                  [
+                    233,
+                    213,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.6196078431372549,
+                  [
+                    235,
+                    211,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.6235294117647059,
+                  [
+                    236,
+                    209,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6274509803921569,
+                  [
+                    238,
+                    207,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6313725490196078,
+                  [
+                    239,
+                    205,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6352941176470588,
+                  [
+                    241,
+                    203,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6392156862745098,
+                  [
+                    242,
+                    201,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6431372549019607,
+                  [
+                    244,
+                    199,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6470588235294118,
+                  [
+                    245,
+                    197,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6509803921568628,
+                  [
+                    246,
+                    195,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6549019607843137,
+                  [
+                    247,
+                    193,
+                    58,
+                    255
+                  ]
+                ],
+                [
+                  0.6588235294117647,
+                  [
+                    248,
+                    190,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.6627450980392157,
+                  [
+                    249,
+                    188,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.6666666666666666,
+                  [
+                    250,
+                    186,
+                    57,
+                    255
+                  ]
+                ],
+                [
+                  0.6705882352941176,
+                  [
+                    251,
+                    184,
+                    56,
+                    255
+                  ]
+                ],
+                [
+                  0.6745098039215687,
+                  [
+                    251,
+                    182,
+                    55,
+                    255
+                  ]
+                ],
+                [
+                  0.6784313725490196,
+                  [
+                    252,
+                    179,
+                    54,
+                    255
+                  ]
+                ],
+                [
+                  0.6823529411764706,
+                  [
+                    252,
+                    177,
+                    54,
+                    255
+                  ]
+                ],
+                [
+                  0.6862745098039216,
+                  [
+                    253,
+                    174,
+                    53,
+                    255
+                  ]
+                ],
+                [
+                  0.6901960784313725,
+                  [
+                    253,
+                    172,
+                    52,
+                    255
+                  ]
+                ],
+                [
+                  0.6941176470588235,
+                  [
+                    254,
+                    169,
+                    51,
+                    255
+                  ]
+                ],
+                [
+                  0.6980392156862745,
+                  [
+                    254,
+                    167,
+                    50,
+                    255
+                  ]
+                ],
+                [
+                  0.7019607843137254,
+                  [
+                    254,
+                    164,
+                    49,
+                    255
+                  ]
+                ],
+                [
+                  0.7058823529411764,
+                  [
+                    254,
+                    161,
+                    48,
+                    255
+                  ]
+                ],
+                [
+                  0.7098039215686275,
+                  [
+                    254,
+                    158,
+                    47,
+                    255
+                  ]
+                ],
+                [
+                  0.7137254901960784,
+                  [
+                    254,
+                    155,
+                    45,
+                    255
+                  ]
+                ],
+                [
+                  0.7176470588235294,
+                  [
+                    254,
+                    153,
+                    44,
+                    255
+                  ]
+                ],
+                [
+                  0.7215686274509804,
+                  [
+                    254,
+                    150,
+                    43,
+                    255
+                  ]
+                ],
+                [
+                  0.7254901960784313,
+                  [
+                    254,
+                    147,
+                    42,
+                    255
+                  ]
+                ],
+                [
+                  0.7294117647058823,
+                  [
+                    254,
+                    144,
+                    41,
+                    255
+                  ]
+                ],
+                [
+                  0.7333333333333333,
+                  [
+                    253,
+                    141,
+                    39,
+                    255
+                  ]
+                ],
+                [
+                  0.7372549019607844,
+                  [
+                    253,
+                    138,
+                    38,
+                    255
+                  ]
+                ],
+                [
+                  0.7411764705882353,
+                  [
+                    252,
+                    135,
+                    37,
+                    255
+                  ]
+                ],
+                [
+                  0.7450980392156863,
+                  [
+                    252,
+                    132,
+                    35,
+                    255
+                  ]
+                ],
+                [
+                  0.7490196078431373,
+                  [
+                    251,
+                    129,
+                    34,
+                    255
+                  ]
+                ],
+                [
+                  0.7529411764705882,
+                  [
+                    251,
+                    126,
+                    33,
+                    255
+                  ]
+                ],
+                [
+                  0.7568627450980392,
+                  [
+                    250,
+                    123,
+                    31,
+                    255
+                  ]
+                ],
+                [
+                  0.7607843137254902,
+                  [
+                    249,
+                    120,
+                    30,
+                    255
+                  ]
+                ],
+                [
+                  0.7647058823529411,
+                  [
+                    249,
+                    117,
+                    29,
+                    255
+                  ]
+                ],
+                [
+                  0.7686274509803921,
+                  [
+                    248,
+                    114,
+                    28,
+                    255
+                  ]
+                ],
+                [
+                  0.7725490196078432,
+                  [
+                    247,
+                    111,
+                    26,
+                    255
+                  ]
+                ],
+                [
+                  0.7764705882352941,
+                  [
+                    246,
+                    108,
+                    25,
+                    255
+                  ]
+                ],
+                [
+                  0.7803921568627451,
+                  [
+                    245,
+                    105,
+                    24,
+                    255
+                  ]
+                ],
+                [
+                  0.7843137254901961,
+                  [
+                    244,
+                    102,
+                    23,
+                    255
+                  ]
+                ],
+                [
+                  0.788235294117647,
+                  [
+                    243,
+                    99,
+                    21,
+                    255
+                  ]
+                ],
+                [
+                  0.792156862745098,
+                  [
+                    242,
+                    96,
+                    20,
+                    255
+                  ]
+                ],
+                [
+                  0.796078431372549,
+                  [
+                    241,
+                    93,
+                    19,
+                    255
+                  ]
+                ],
+                [
+                  0.8,
+                  [
+                    240,
+                    91,
+                    18,
+                    255
+                  ]
+                ],
+                [
+                  0.803921568627451,
+                  [
+                    239,
+                    88,
+                    17,
+                    255
+                  ]
+                ],
+                [
+                  0.807843137254902,
+                  [
+                    237,
+                    85,
+                    16,
+                    255
+                  ]
+                ],
+                [
+                  0.8117647058823529,
+                  [
+                    236,
+                    83,
+                    15,
+                    255
+                  ]
+                ],
+                [
+                  0.8156862745098039,
+                  [
+                    235,
+                    80,
+                    14,
+                    255
+                  ]
+                ],
+                [
+                  0.8196078431372549,
+                  [
+                    234,
+                    78,
+                    13,
+                    255
+                  ]
+                ],
+                [
+                  0.8235294117647058,
+                  [
+                    232,
+                    75,
+                    12,
+                    255
+                  ]
+                ],
+                [
+                  0.8274509803921568,
+                  [
+                    231,
+                    73,
+                    12,
+                    255
+                  ]
+                ],
+                [
+                  0.8313725490196078,
+                  [
+                    229,
+                    71,
+                    11,
+                    255
+                  ]
+                ],
+                [
+                  0.8352941176470589,
+                  [
+                    228,
+                    69,
+                    10,
+                    255
+                  ]
+                ],
+                [
+                  0.8392156862745098,
+                  [
+                    226,
+                    67,
+                    10,
+                    255
+                  ]
+                ],
+                [
+                  0.8431372549019608,
+                  [
+                    225,
+                    65,
+                    9,
+                    255
+                  ]
+                ],
+                [
+                  0.8470588235294118,
+                  [
+                    223,
+                    63,
+                    8,
+                    255
+                  ]
+                ],
+                [
+                  0.8509803921568627,
+                  [
+                    221,
+                    61,
+                    8,
+                    255
+                  ]
+                ],
+                [
+                  0.8549019607843137,
+                  [
+                    220,
+                    59,
+                    7,
+                    255
+                  ]
+                ],
+                [
+                  0.8588235294117647,
+                  [
+                    218,
+                    57,
+                    7,
+                    255
+                  ]
+                ],
+                [
+                  0.8627450980392157,
+                  [
+                    216,
+                    55,
+                    6,
+                    255
+                  ]
+                ],
+                [
+                  0.8666666666666667,
+                  [
+                    214,
+                    53,
+                    6,
+                    255
+                  ]
+                ],
+                [
+                  0.8705882352941177,
+                  [
+                    212,
+                    51,
+                    5,
+                    255
+                  ]
+                ],
+                [
+                  0.8745098039215686,
+                  [
+                    210,
+                    49,
+                    5,
+                    255
+                  ]
+                ],
+                [
+                  0.8784313725490196,
+                  [
+                    208,
+                    47,
+                    5,
+                    255
+                  ]
+                ],
+                [
+                  0.8823529411764706,
+                  [
+                    206,
+                    45,
+                    4,
+                    255
+                  ]
+                ],
+                [
+                  0.8862745098039215,
+                  [
+                    204,
+                    43,
+                    4,
+                    255
+                  ]
+                ],
+                [
+                  0.8901960784313725,
+                  [
+                    202,
+                    42,
+                    4,
+                    255
+                  ]
+                ],
+                [
+                  0.8941176470588235,
+                  [
+                    200,
+                    40,
+                    3,
+                    255
+                  ]
+                ],
+                [
+                  0.8980392156862745,
+                  [
+                    197,
+                    38,
+                    3,
+                    255
+                  ]
+                ],
+                [
+                  0.9019607843137255,
+                  [
+                    195,
+                    37,
+                    3,
+                    255
+                  ]
+                ],
+                [
+                  0.9058823529411765,
+                  [
+                    193,
+                    35,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9098039215686274,
+                  [
+                    190,
+                    33,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9137254901960784,
+                  [
+                    188,
+                    32,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9176470588235294,
+                  [
+                    185,
+                    30,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9215686274509803,
+                  [
+                    183,
+                    29,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9254901960784314,
+                  [
+                    180,
+                    27,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9294117647058824,
+                  [
+                    178,
+                    26,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9333333333333333,
+                  [
+                    175,
+                    24,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9372549019607843,
+                  [
+                    172,
+                    23,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9411764705882353,
+                  [
+                    169,
+                    22,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9450980392156862,
+                  [
+                    167,
+                    20,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9490196078431372,
+                  [
+                    164,
+                    19,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9529411764705882,
+                  [
+                    161,
+                    18,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9568627450980391,
+                  [
+                    158,
+                    16,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9607843137254902,
+                  [
+                    155,
+                    15,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9647058823529412,
+                  [
+                    152,
+                    14,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9686274509803922,
+                  [
+                    149,
+                    13,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9725490196078431,
+                  [
+                    146,
+                    11,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9764705882352941,
+                  [
+                    142,
+                    10,
+                    1,
+                    255
+                  ]
+                ],
+                [
+                  0.9803921568627451,
+                  [
+                    139,
+                    9,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.984313725490196,
+                  [
+                    136,
+                    8,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9882352941176471,
+                  [
+                    133,
+                    7,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.9921568627450981,
+                  [
+                    129,
+                    6,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  0.996078431372549,
+                  [
+                    126,
+                    5,
+                    2,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    122,
+                    4,
+                    3,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": false
+            },
+            "levels": [
+              2.534584077925331,
+              3.2496226966715804
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb00030000000003a00000086d000006bf00000ba8000003a000000889000006bf00000ba800000000000000000c00000003a000000889000006bf00000ba8"
+      }
+    },
+    {
+      "class": "ImageViewer",
+      "name": "ImageViewer.2",
+      "state": {
+        "pos": [
+          700.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "jf_n_average",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                295.7482815368675,
+                399.14308737655045
+              ],
+              [
+                685.1520317258422,
+                791.3716600455488
+              ]
+            ],
+            "viewRange": [
+              [
+                295.7482815368675,
+                399.14308737655045
+              ],
+              [
+                685.1520317258422,
+                791.3716600455488
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              -0.00651590028560789,
+              1.025986037909054
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000ad00000089a00000def00000bd500000ad0000008b600000def00000bd500000000000000000c0000000ad0000008b600000def00000bd5"
+      }
+    },
+    {
+      "class": "Roi2D",
+      "name": "Roi2D.0",
+      "state": {
+        "pos": [
+          700.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Roi_Coordinates": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "origin x": 128,
+          "origin y": 320,
+          "extent x": 62,
+          "extent y": 25
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -31.275377755214137,
+                543.2753777552141
+              ],
+              [
+                -37.74514077565367,
+                549.7451407756537
+              ]
+            ],
+            "viewRange": [
+              [
+                -31.275377755214137,
+                543.2753777552141
+              ],
+              [
+                -37.74514077565367,
+                549.7451407756537
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.0,
+                  [
+                    68,
+                    1,
+                    84,
+                    255
+                  ]
+                ],
+                [
+                  0.25,
+                  [
+                    58,
+                    82,
+                    139,
+                    255
+                  ]
+                ],
+                [
+                  0.5,
+                  [
+                    32,
+                    144,
+                    140,
+                    255
+                  ]
+                ],
+                [
+                  0.75,
+                  [
+                    94,
+                    201,
+                    97,
+                    255
+                  ]
+                ],
+                [
+                  1.0,
+                  [
+                    253,
+                    231,
+                    36,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              -0.05854922828311615,
+              27.303528984677307
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000a66000002bc00000f730000072f00000a66000002d800000f730000072f00000003000000000c0000000a66000002d800000f730000072f"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.2",
+      "state": {
+        "pos": [
+          800.0,
+          -200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "X.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          },
+          "Y.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          },
+          "X.2": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.2"
+          },
+          "Y.2": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.2"
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": true
+            },
+            "trace.0": "PythonEditor.2.Out.1 vs PythonEditor.2.Out",
+            "trace.1": "Average1D.0.Out vs PythonEditor.2.Out",
+            "trace.2": "Average1D.1.Out vs PythonEditor.2.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "PythonEditor.2.Out.1 vs PythonEditor.2.Out",
+              "PythonEditor.2.Out.1 vs PythonEditor.2.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    170,
+                    255,
+                    255
+                  ],
+                  "width": 4,
+                  "style": "Solid"
+                }
+              }
+            ],
+            "trace.1": [
+              "Average1D.0.Out vs PythonEditor.2.Out",
+              "Average1D.0.Out vs PythonEditor.2.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    0,
+                    255
+                  ],
+                  "width": 2,
+                  "style": "Solid"
+                }
+              }
+            ],
+            "trace.2": [
+              "Average1D.1.Out vs PythonEditor.2.Out",
+              "Average1D.1.Out vs PythonEditor.2.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -2.4945991853584206,
+                5.551842909160262
+              ],
+              [
+                3.9376988997970948,
+                5.149604621667193
+              ]
+            ],
+            "viewRange": [
+              [
+                -2.4945991853584206,
+                5.551842909160262
+              ],
+              [
+                3.9376988997970948,
+                5.149604621667193
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              true
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000002e8000001e0000003f000000001000002e9000001df000003ef00000000000000000f0000000001000002e9000001df000003ef"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.3",
+      "state": {
+        "pos": [
+          800.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": true
+            },
+            "trace.0": "Average1D.0.Out vs PythonEditor.2.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Average1D.0.Out vs PythonEditor.2.Out",
+              "Average1D.0.Out vs PythonEditor.2.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -17.331343401514317,
+                47.6979619384191
+              ],
+              [
+                -2.8862844687844675,
+                5.778019990813574
+              ]
+            ],
+            "viewRange": [
+              [
+                -17.331343401514317,
+                47.6979619384191
+              ],
+              [
+                -2.8862844687844675,
+                5.778019990813574
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              true
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000cb00000123e00000f49000014a700000cb00000125a00000f49000014a700000006000000000a0000000cb00000125a00000f49000014a7"
+      }
+    },
+    {
+      "class": "Sum",
+      "name": "Sum.0",
+      "state": {
+        "pos": [
+          900.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[amitypes.array.Array3d, amitypes.array.Array2d, amitypes.array.Array1d, list[float], tuple[float]]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        }
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.0",
+      "state": {
+        "pos": [
+          1100.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 120,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012260000130f0000153d00000ff0000012260000130f0000153d00000006000000000a0000000ff0000012260000130f0000153d"
+      }
+    },
+    {
+      "class": "Filter",
+      "name": "Filter.0",
+      "state": {
+        "pos": [
+          1100.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out.1": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "conditions": 1,
+          "inputs": {
+            "In": "XppSb2BmMon:raw:totalIntensityJoules",
+            "In.1": "Sum.0.Out"
+          },
+          "outputs": [
+            "Filter.0.Out",
+            "Filter.0.Out.1"
+          ],
+          "If": {
+            "condition": "XppSb2BmMon:raw:totalIntensityJoules  > 1000 and XppSb2BmMon:raw:totalIntensityJoules < 1e6",
+            "Filter.0.Out": "XppSb2BmMon:raw:totalIntensityJoules",
+            "Filter.0.Out.1": "Sum.0.Out"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000e0b0000119b0000112a000014d600000e0b000011b70000112a000014d600000006000000000a0000000e0b000011b70000112a000014d6"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.2",
+      "state": {
+        "pos": [
+          1300.0,
+          700.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 120,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb00030000000011ca00001250000014e90000156f000011ca00001250000014e90000156f00000006000000000a00000011ca00001250000014e90000156f"
+      }
+    },
+    {
+      "class": "Average0D",
+      "name": "Average0D.3",
+      "state": {
+        "pos": [
+          1300.0,
+          900.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 120,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012030000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e"
+      }
+    },
+    {
+      "class": "Calculator",
+      "name": "Calculator.3",
+      "state": {
+        "pos": [
+          1300.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "operation": "Average0D.0.Out/44000"
+        },
+        "geometry": "01d9d0cb0003000000000f80000012230000129f0000154200000f80000012230000129f0000154200000006000000000a0000000f80000012230000129f00001542"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.0",
+      "state": {
+        "pos": [
+          1400.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Value.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "float",
+            "optional": false,
+            "group": "group.1"
+          },
+          "Counts.1": {
+            "io": "out",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.1",
+      "state": {
+        "pos": [
+          1400.0,
+          1400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Value.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "float",
+            "optional": false,
+            "group": "group.1"
+          },
+          "Counts.1": {
+            "io": "out",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": "group.1"
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 10,
+          "min": 0,
+          "max": 10
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012030000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e"
+      }
+    },
+    {
+      "class": "TimePlot",
+      "name": "TimePlot.0",
+      "state": {
+        "pos": [
+          1500.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "jf_roi_time",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 1000
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Sum.0.Out vs timestamp"
+          },
+          "legend": {
+            "trace.0": [
+              "Calculator.3.Out vs timestamp",
+              "Sum.0.Out vs timestamp",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    30,
+                    225,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1776785472.5332649,
+                1776785477.110636
+              ],
+              [
+                0.10213789683190005,
+                0.10227474742039884
+              ]
+            ],
+            "viewRange": [
+              [
+                1776785472.5332649,
+                1776785477.110636
+              ],
+              [
+                0.10213789683190005,
+                0.10227474742039884
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -62135596800.0,
+                253370764800.0
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000003f00000029a000004f800000001000003f100000299000004f700000000000000000f0000000001000003f100000299000004f7"
+      }
+    },
+    {
+      "class": "Calculator",
+      "name": "Calculator.0",
+      "state": {
+        "pos": [
+          1500.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "operation": "Average0D.3.Out / Average0D.2.Out/0.375"
+        },
+        "geometry": "01d9d0cb0003000000000cd00000126300000fef0000158200000cd00000126300000fef0000158200000006000000000a0000000cd00000126300000fef00001582"
+      }
+    },
+    {
+      "class": "Calculator",
+      "name": "Calculator.1",
+      "state": {
+        "pos": [
+          1600.0,
+          1200.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "operation": "MeanVsScan.0.Counts/MeanVsScan.0.Counts.1"
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012030000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e"
+      }
+    },
+    {
+      "class": "Calculator",
+      "name": "Calculator.2",
+      "state": {
+        "pos": [
+          1600.0,
+          1500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "In.1": {
+            "io": "in",
+            "removable": true,
+            "ttype": "typing.Union[float, amitypes.array.Array1d, amitypes.array.Array2d, amitypes.array.Array3d]",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "operation": "MeanVsScan.1.Counts/MeanVsScan.1.Counts.1"
+        },
+        "geometry": "01d9d0cb0003000000000ff0000012030000130f0000153e00000ff00000121f0000130f0000153e00000006000000000a0000000ff00000121f0000130f0000153e"
+      }
+    },
+    {
+      "class": "TimePlot",
+      "name": "TimePlot.2",
+      "state": {
+        "pos": [
+          1700.0,
+          800.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "jf_normalized_time",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 1000
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Calculator.0.Out vs timestamp"
+          },
+          "legend": {
+            "trace.0": [
+              "Calculator.0.Out vs timestamp",
+              "Calculator.0.Out vs timestamp",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    30,
+                    225,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                1776665361.9185107,
+                1776665375.0312552
+              ],
+              [
+                0.0034473786793306274,
+                0.35925066356470525
+              ]
+            ],
+            "viewRange": [
+              [
+                1776665361.9185107,
+                1776665375.0312552
+              ],
+              [
+                0.0034473786793306274,
+                0.35925066356470525
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -62135596800.0,
+                253370764800.0
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000003c0000003f0000005a0000004f8000003c1000003f10000059f000004f700000000000000000f00000003c1000003f10000059f000004f7"
+      }
+    },
+    {
+      "class": "ScatterPlot",
+      "name": "ScatterPlot.1",
+      "state": {
+        "pos": [
+          1700.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "Num Points": 400,
+          "Unique": false
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Sum.0.Out vs XppSb2BmMon:raw:totalIntensityJoules"
+          },
+          "legend": {
+            "trace.0": [
+              "Sum.0.Out vs XppSb2BmMon:raw:totalIntensityJoules",
+              "Sum.0.Out vs XppSb2BmMon:raw:totalIntensityJoules",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "Size": 8
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "None"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                3689.589985610171,
+                12351.695728675533
+              ],
+              [
+                -6.823065735799177,
+                6.823065735799177
+              ]
+            ],
+            "viewRange": [
+              [
+                3689.589985610171,
+                12351.695728675533
+              ],
+              [
+                -6.823065735799177,
+                6.823065735799177
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000000d0a000012af00001028000015ea00000d0a000012cb00001028000015ea00000006000000000a0000000d0a000012cb00001028000015ea"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.0",
+      "state": {
+        "pos": [
+          1800.0,
+          1100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "scan_filtered",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Calculator.1.Out vs MeanVsScan.0.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "Calculator.1.Out vs MeanVsScan.0.Bins",
+              "Calculator.1.Out vs MeanVsScan.0.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                21.309271070006712,
+                21.314088304993287
+              ],
+              [
+                0.00013838003414001242,
+                0.0001878153987215278
+              ]
+            ],
+            "viewRange": [
+              [
+                21.309271070006712,
+                21.314088304993287
+              ],
+              [
+                0.00013838003414001242,
+                0.0001878153987215278
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000003c0000004f8000005a000000600000003c1000004f90000059f000005ff00000000000000000f00000003c1000004f90000059f000005ff"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.1",
+      "state": {
+        "pos": [
+          1800.0,
+          1400.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "scan_not_filtered",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "trace.0": "Calculator.2.Out vs MeanVsScan.1.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "Calculator.2.Out vs MeanVsScan.1.Bins",
+              "Calculator.2.Out vs MeanVsScan.1.Bins",
+              {
+                "Point": {
+                  "symbol": "o",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    0,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -4.718137022394236,
+                104.64850342973833
+              ],
+              [
+                -31909.38894924322,
+                380341.08823829284
+              ]
+            ],
+            "viewRange": [
+              [
+                -4.718137022394236,
+                104.64850342973833
+              ],
+              [
+                -31909.38894924322,
+                380341.08823829284
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb00030000000003c0000002e8000005a0000003f0000003c1000002e90000059f000003ef00000000000000000f00000003c1000002e90000059f000003ef"
+      }
+    }
+  ],
+  "connects": [
+    [
+      "jungfrau1M:raw:image",
+      "Out",
+      "PythonEditor.0",
+      "In"
+    ],
+    [
+      "jungfrau1M:raw:image",
+      "Out",
+      "PythonEditor.1",
+      "In"
+    ],
+    [
+      "jungfrau1M:raw:image",
+      "Out",
+      "PythonEditor.2",
+      "In"
+    ],
+    [
+      "timestamp",
+      "Out",
+      "TimePlot.0",
+      "X"
+    ],
+    [
+      "timestamp",
+      "Out",
+      "TimePlot.1",
+      "X"
+    ],
+    [
+      "timestamp",
+      "Out",
+      "TimePlot.2",
+      "X"
+    ],
+    [
+      "XppSb2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "Average0D.1",
+      "In"
+    ],
+    [
+      "XppSb2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "Filter.0",
+      "In"
+    ],
+    [
+      "XppSb2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "MeanVsScan.1",
+      "Value.1"
+    ],
+    [
+      "XppSb2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "ScatterPlot.0",
+      "Y"
+    ],
+    [
+      "XppSb2BmMon:raw:totalIntensityJoules",
+      "Out",
+      "ScatterPlot.1",
+      "X"
+    ],
+    [
+      "ebeamh:raw:ebeamL3Energy",
+      "Out",
+      "ScatterPlot.0",
+      "X"
+    ],
+    [
+      "alvium:raw:value",
+      "Out",
+      "ImageViewer.3",
+      "In"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "ImageViewer.0",
+      "In"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "Average2D.0",
+      "In"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "Average2D.1",
+      "In"
+    ],
+    [
+      "Average0D.1",
+      "Out",
+      "TimePlot.1",
+      "Y"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "LinePlot.2",
+      "X"
+    ],
+    [
+      "PythonEditor.2",
+      "Out.1",
+      "LinePlot.2",
+      "Y"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "LinePlot.2",
+      "X.1"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "LinePlot.2",
+      "X.2"
+    ],
+    [
+      "PythonEditor.2",
+      "Out.1",
+      "Average1D.0",
+      "In"
+    ],
+    [
+      "PythonEditor.2",
+      "Out",
+      "LinePlot.3",
+      "X"
+    ],
+    [
+      "PythonEditor.2",
+      "Out.1",
+      "Average1D.1",
+      "In"
+    ],
+    [
+      "Average2D.0",
+      "Out",
+      "ImageViewer.1",
+      "In"
+    ],
+    [
+      "Average2D.1",
+      "Out",
+      "ImageViewer.2",
+      "In"
+    ],
+    [
+      "PythonEditor.1",
+      "Out",
+      "Roi2D.0",
+      "In"
+    ],
+    [
+      "Average1D.0",
+      "Out",
+      "LinePlot.2",
+      "Y.1"
+    ],
+    [
+      "Average1D.0",
+      "Out",
+      "LinePlot.3",
+      "Y"
+    ],
+    [
+      "Average1D.1",
+      "Out",
+      "LinePlot.2",
+      "Y.2"
+    ],
+    [
+      "m1_ry",
+      "Out",
+      "MeanVsScan.0",
+      "Bin"
+    ],
+    [
+      "m1_ry",
+      "Out",
+      "MeanVsScan.1",
+      "Bin"
+    ],
+    [
+      "Roi2D.0",
+      "Out",
+      "Sum.0",
+      "In"
+    ],
+    [
+      "Sum.0",
+      "Out",
+      "Average0D.0",
+      "In"
+    ],
+    [
+      "Sum.0",
+      "Out",
+      "Filter.0",
+      "In.1"
+    ],
+    [
+      "Sum.0",
+      "Out",
+      "MeanVsScan.1",
+      "Value"
+    ],
+    [
+      "Sum.0",
+      "Out",
+      "ScatterPlot.1",
+      "Y"
+    ],
+    [
+      "Average0D.0",
+      "Out",
+      "Calculator.3",
+      "In"
+    ],
+    [
+      "Filter.0",
+      "Out",
+      "Average0D.2",
+      "In"
+    ],
+    [
+      "Filter.0",
+      "Out.1",
+      "Average0D.3",
+      "In"
+    ],
+    [
+      "Filter.0",
+      "Out",
+      "MeanVsScan.0",
+      "Value.1"
+    ],
+    [
+      "Filter.0",
+      "Out.1",
+      "MeanVsScan.0",
+      "Value"
+    ],
+    [
+      "Average0D.2",
+      "Out",
+      "Calculator.0",
+      "In"
+    ],
+    [
+      "Average0D.3",
+      "Out",
+      "Calculator.0",
+      "In.1"
+    ],
+    [
+      "Calculator.3",
+      "Out",
+      "TimePlot.0",
+      "Y"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts.1",
+      "Calculator.1",
+      "In.1"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts",
+      "Calculator.1",
+      "In"
+    ],
+    [
+      "MeanVsScan.0",
+      "Bins",
+      "LinePlot.0",
+      "X"
+    ],
+    [
+      "MeanVsScan.1",
+      "Counts",
+      "Calculator.2",
+      "In"
+    ],
+    [
+      "MeanVsScan.1",
+      "Counts.1",
+      "Calculator.2",
+      "In.1"
+    ],
+    [
+      "MeanVsScan.1",
+      "Bins",
+      "LinePlot.1",
+      "X"
+    ],
+    [
+      "Calculator.0",
+      "Out",
+      "TimePlot.2",
+      "Y"
+    ],
+    [
+      "Calculator.1",
+      "Out",
+      "LinePlot.0",
+      "Y"
+    ],
+    [
+      "Calculator.2",
+      "Out",
+      "LinePlot.1",
+      "Y"
+    ]
+  ],
+  "viewbox": {
+    "comments": []
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": [
+      "/sdf/home/x/xppopr/daq/ami_graphs/threshold_detector.py"
+    ]
+  }
+}

--- a/tests/graphs/rad_integral.fc
+++ b/tests/graphs/rad_integral.fc
@@ -1,0 +1,721 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "jungfrau:raw:image",
+      "state": {
+        "pos": [
+          200.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -170.96600076209057,
+                4386.9660007620905
+              ],
+              [
+                -165.17088793798447,
+                4597.170887937985
+              ]
+            ],
+            "viewRange": [
+              [
+                -170.96600076209057,
+                4386.9660007620905
+              ],
+              [
+                -165.17088793798447,
+                4597.170887937985
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.3333,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6666,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              -2.5378520488739014,
+              1.4620009660720825
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000000000000000000031f0000031f00000000000000000000031f0000031f00000005000000000f0000000000000000000000031f0000031f",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "RadialProjection.0",
+      "state": {
+        "pos": [
+          400.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": true,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "In": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\n\nclass EventProcessor():\n\n    def __init__(self):\n        self.cx = 2000\n        self.cy = 2100\n\n    def begin_run(self):\n        pass\n\n    def end_run(self):\n        pass\n\n    def begin_step(self, step):\n        pass\n\n    def end_step(self, step):\n        pass\n\n    def on_event(self, In, *args, **kwargs):\n        img = np.asarray(In, dtype=np.float64)\n\n        if img.ndim != 2:\n            return np.array([], dtype=np.float64)\n\n        yy, xx = np.indices(img.shape)\n        rr = np.hypot(xx - self.cx, yy - self.cy).astype(np.int32)\n\n        radial_sum = np.bincount(rr.ravel(), weights=img.ravel())\n        radial_count = np.bincount(rr.ravel())\n\n        radial_profile = np.divide(\n            radial_sum,\n            radial_count,\n            out=np.zeros_like(radial_sum, dtype=np.float64),\n            where=radial_count > 0\n        )\n\n        return radial_profile"
+        },
+        "geometry": "01d9d0cb0003000000000afa0000097300000e1900000cb700000afa0000099800000e1900000cb700000000000000000a0000000afa0000099800000e1900000cb7"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.0",
+      "state": {
+        "pos": [
+          600.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "Radial projection (center: 2000,2100)",
+            "Show Grid": false,
+            "X Axis": {
+              "Label": "radius (pixels)",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "mean intensity",
+              "Log Scale": false
+            },
+            "trace.0": "RadialProjection.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "RadialProjection.0.Out",
+              "RadialProjection.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 10
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 2,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -127.162919906475,
+                3342.162919906475
+              ],
+              [
+                -0.253355175273683,
+                1.9393150977819023
+              ]
+            ],
+            "viewRange": [
+              [
+                -127.162919906475,
+                3342.162919906475
+              ],
+              [
+                -0.253355175273683,
+                1.9393150977819023
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          }
+        },
+        "geometry": "01d9d0cb0003000000001066000008fa0000138500000c3e000010660000091f0000138500000c3e00000000000000000a00000010660000091f0000138500000c3e"
+      }
+    },
+    {
+      "class": "RoiArch",
+      "name": "RoiArch.0",
+      "state": {
+        "pos": [
+          400.0,
+          -300.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "image": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "mask": {
+            "io": "in",
+            "removable": true,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "RBinCent": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "ABinCent": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "RBinEdges": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "ABinEdges": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "RadAngNormIntens": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "RadAngBinStatist": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "RProj": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "AProj": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "ROIPars": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "BBox": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Mask": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "center x": 2129,
+          "center y": 2203,
+          "radius o": 1653,
+          "radius i": 265,
+          "angdeg o": 268,
+          "angdeg i": 328,
+          "nbins rad": 100,
+          "nbins ang": 5
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -141.73306189391724,
+                4440.340797142035
+              ],
+              [
+                -815.7388616639075,
+                4004.2278786256193
+              ]
+            ],
+            "viewRange": [
+              [
+                -141.73306189391724,
+                4440.340797142035
+              ],
+              [
+                -815.7388616639075,
+                4004.2278786256193
+              ]
+            ],
+            "yInverted": true,
+            "xInverted": false,
+            "aspectLocked": 1,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "yLimits": [
+                -1e+307,
+                1e+307
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.3333,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6666,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              -2.686429500579834,
+              1.5170294046401978
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000a0f000009c300000d9200000c3f00000a0f000009e800000d9200000c3f00000000000000000a0000000a0f000009e800000d9200000c3f"
+      }
+    },
+    {
+      "class": "Average2D",
+      "name": "Average2D.0",
+      "state": {
+        "pos": [
+          400.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "N": 10,
+          "infinite": false
+        },
+        "geometry": "01d9d0cb0003000000000a000000088c00000d1f00000bd000000a00000008b100000d1f00000bd000000000000000000a0000000a00000008b100000d1f00000bd0"
+      }
+    },
+    {
+      "class": "ImageViewer",
+      "name": "ImageViewer.0",
+      "state": {
+        "pos": [
+          600.0,
+          0.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        }
+      }
+    }
+  ],
+  "connects": [
+    [
+      "jungfrau:raw:image",
+      "Out",
+      "RadialProjection.0",
+      "In"
+    ],
+    [
+      "jungfrau:raw:image",
+      "Out",
+      "RoiArch.0",
+      "image"
+    ],
+    [
+      "jungfrau:raw:image",
+      "Out",
+      "RoiArch.0",
+      "mask"
+    ],
+    [
+      "jungfrau:raw:image",
+      "Out",
+      "Average2D.0",
+      "In"
+    ],
+    [
+      "RadialProjection.0",
+      "Out",
+      "WaveformViewer.0",
+      "In"
+    ],
+    [
+      "Average2D.0",
+      "Out",
+      "ImageViewer.0",
+      "In"
+    ]
+  ],
+  "viewbox": {
+    "comments": [
+      {
+        "id": 3,
+        "text": "Peak position histogram",
+        "topLeft": [
+          500.0,
+          0.0
+        ],
+        "bottomRight": [
+          1200.0,
+          300.0
+        ]
+      }
+    ]
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": []
+  }
+}

--- a/tests/graphs/spike_no_ped.fc
+++ b/tests/graphs/spike_no_ped.fc
@@ -1,0 +1,1184 @@
+{
+  "nodes": [
+    {
+      "class": "SourceNode",
+      "name": "manta:raw:value",
+      "state": {
+        "pos": [
+          0.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": true,
+              "Auto Levels": true,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -83.6136048756672,
+                2131.613604875667
+              ],
+              [
+                -15.043548288892032,
+                415.04354828889205
+              ]
+            ],
+            "viewRange": [
+              [
+                -83.6136048756672,
+                2131.613604875667
+              ],
+              [
+                -15.043548288892032,
+                415.04354828889205
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              true
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "screenshot_enabled": false,
+          "screenshot_dir": "./screenshots",
+          "screenshot_counter": 0,
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.3333,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6666,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              0,
+              62
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb0003000000000a8200000c5200000da100000f9600000a8200000c7700000da100000f9600000002000000000f0000000a8200000c7700000da100000f96",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "SourceNode",
+      "name": "step_value",
+      "state": {
+        "pos": [
+          100.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          }
+        },
+        "geometry": "01d9d0cb00030000000000280000003f000003470000035e000000280000003f000003470000035e000000000000000005a0000000280000003f000003470000035e",
+        "source_kwargs": {}
+      }
+    },
+    {
+      "class": "Roi2D",
+      "name": "Roi2D.0",
+      "state": {
+        "pos": [
+          200.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Roi_Coordinates": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "origin x": 38,
+          "origin y": 29,
+          "extent x": 390,
+          "extent y": 400
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Histogram": {
+              "Auto Range": false,
+              "Auto Levels": false,
+              "Log Scale": false
+            },
+            "Display": {
+              "Lock Aspect Ratio": true,
+              "Flip": false,
+              "Rotate Counter Clockwise": "0"
+            }
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -21.044181267016032,
+                533.044181267016
+              ],
+              [
+                -28.986292074101648,
+                540.9862920741017
+              ]
+            ],
+            "viewRange": [
+              [
+                -21.044181267016032,
+                533.044181267016
+              ],
+              [
+                -28.986292074101648,
+                540.9862920741017
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "screenshot_enabled": false,
+          "screenshot_dir": "./screenshots",
+          "screenshot_counter": 0,
+          "histogramLUT": {
+            "gradient": {
+              "mode": "rgb",
+              "ticks": [
+                [
+                  0.3333,
+                  [
+                    185,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  0.6666,
+                  [
+                    255,
+                    220,
+                    0,
+                    255
+                  ]
+                ],
+                [
+                  1,
+                  [
+                    255,
+                    255,
+                    255,
+                    255
+                  ]
+                ],
+                [
+                  0,
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ]
+              ],
+              "ticksVisible": true
+            },
+            "levels": [
+              -73.94582156866022,
+              117.04275051906717
+            ],
+            "mode": "mono"
+          }
+        },
+        "geometry": "01d9d0cb000300000000000000000018000003c0000001a00000000100000019000003bf0000019f000000000000000007800000000100000019000003bf0000019f"
+      }
+    },
+    {
+      "class": "PythonEditor",
+      "name": "PythonEditor.0",
+      "state": {
+        "pos": [
+          400.0,
+          200.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          },
+          "Out.1": {
+            "io": "out",
+            "removable": true,
+            "ttype": "typing.Any",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "text": "import numpy as np\nimport scipy\n\n# entry point must be called func\n\n\ndef func(manta_raw_value, *args, **kwargs):\n\n    raw_image_array = manta_raw_value.astype(np.float32)\n\n    # Rotate the image if needed\n    #This angle needs to be set during the beamtime, it is the camera axis misalignment to the beam\n    angle = 0.0\n    # I'm not sure if this is the best function for image rotation\n    image = scipy.ndimage.rotate(raw_image_array, angle, reshape=False)\n    #image=raw_image_array\n    # Sum the image orthogonal to the dispersion direction\n    proj_image = np.sum(image,0)\n\n    # Calculate the figure of merit\n    # This FOM is related to the gradient in the spectrum (spikiness) \n    proj1 = proj_image[0:np.size(proj_image)-1]\n    proj2 = proj_image[1:np.size(proj_image)]\n    #proj1 = proj_image[0:np.size(proj_image)-9] +proj_image[1:np.size(proj_image)-8]+proj_image[2:np.size(proj_image)-7]+proj_image[3:np.size(proj_image)-6]+proj_image[4:np.size(proj_image)-5]\n    #proj2 = proj_image[5:np.size(proj_image)-4]+proj_image[6:np.size(proj_image)-3]+proj_image[7:np.size(proj_image)-2]+proj_image[8:np.size(proj_image)-1]+proj_image[9:np.size(proj_image)]\n    fig_of_merit = np.sum(np.abs(proj1-proj2))\n\n    #Thought that we might need a normalized figure of merit\n    fig_of_merit_norm = np.sum(np.abs(proj1-proj2))/np.sum(np.abs(proj1+proj2))\n    return fig_of_merit, fig_of_merit_norm"
+        },
+        "geometry": "01d9d0cb00030000000003c00000001800000780000001a0000003c1000000190000077f0000019f00000000000000000780000003c1000000190000077f0000019f"
+      }
+    },
+    {
+      "class": "Projection",
+      "name": "Projection.0",
+      "state": {
+        "pos": [
+          600.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array2d",
+            "optional": false,
+            "group": null
+          },
+          "Out": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "axis": 0
+        },
+        "geometry": "01d9d0cb0003000000000000000011030000031f00001449000000000000112a0000031f0000144900000000000000000f00000000000000112a0000031f00001449"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.0",
+      "state": {
+        "pos": [
+          600.0,
+          400.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 20,
+          "min": 0,
+          "max": 20
+        },
+        "geometry": "01d9d0cb0003000000000f2d0000110d0000124c0000145100000f2d000011320000124c0000145100000001000000000f0000000f2d000011320000124c00001451"
+      }
+    },
+    {
+      "class": "MeanVsScan",
+      "name": "MeanVsScan.1",
+      "state": {
+        "pos": [
+          600.0,
+          600.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "Bin": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Value": {
+            "io": "in",
+            "removable": false,
+            "ttype": "float",
+            "optional": false,
+            "group": null
+          },
+          "Bins": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Counts": {
+            "io": "out",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "ctrl": {
+          "binned": false,
+          "bins": 20,
+          "min": 0,
+          "max": 20
+        },
+        "geometry": "01d9d0cb0003000000000f2d0000110d0000124c0000145100000f2d000011320000124c0000145100000001000000000f0000000f2d000011320000124c00001451"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.0",
+      "state": {
+        "pos": [
+          800.0,
+          300.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Screenshots": {
+              "Record Screenshots": false,
+              "Screenshot Directory": "./screenshots"
+            },
+            "trace.0": "MeanVsScan.0.Counts vs MeanVsScan.0.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              "MeanVsScan.0.Counts vs MeanVsScan.0.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -2.8381912068951256,
+                103.03984881503479
+              ],
+              [
+                -1728.815907620563,
+                1728.815907620563
+              ]
+            ],
+            "viewRange": [
+              [
+                -2.8381912068951256,
+                103.03984881503479
+              ],
+              [
+                -1728.815907620563,
+                1728.815907620563
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              1.0,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "screenshot_enabled": false,
+          "screenshot_dir": "./screenshots",
+          "screenshot_counter": 0
+        },
+        "geometry": "01d9d0cb0003000000000000000001a0000003c00000032800000001000001a1000003bf000003270000000000000000078000000001000001a1000003bf00000327"
+      }
+    },
+    {
+      "class": "LinePlot",
+      "name": "LinePlot.1",
+      "state": {
+        "pos": [
+          800.0,
+          500.0
+        ],
+        "enabled": true,
+        "viewed": true,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "X": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          },
+          "Y": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Screenshots": {
+              "Record Screenshots": false,
+              "Screenshot Directory": "./screenshots"
+            },
+            "trace.0": "MeanVsScan.1.Counts vs MeanVsScan.1.Bins"
+          },
+          "legend": {
+            "trace.0": [
+              "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+              "MeanVsScan.1.Counts vs MeanVsScan.1.Bins",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    255,
+                    255,
+                    255
+                  ],
+                  "width": 3,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -3.023984582246168,
+                103.22564219038583
+              ],
+              [
+                0.023220963015845746,
+                0.025017223149844676
+              ]
+            ],
+            "viewRange": [
+              [
+                -3.023984582246168,
+                103.22564219038583
+              ],
+              [
+                0.023220963015845746,
+                0.025017223149844676
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              true,
+              1.0
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "screenshot_enabled": false,
+          "screenshot_dir": "./screenshots",
+          "screenshot_counter": 0
+        },
+        "geometry": "01d9d0cb000300000000000000000328000003c0000004b00000000100000329000003bf000004af000000000000000007800000000100000329000003bf000004af"
+      }
+    },
+    {
+      "class": "WaveformViewer",
+      "name": "WaveformViewer.0",
+      "state": {
+        "pos": [
+          800.0,
+          100.0
+        ],
+        "enabled": true,
+        "viewed": false,
+        "latched": false,
+        "label": "",
+        "terminals": {
+          "In": {
+            "io": "in",
+            "removable": false,
+            "ttype": "amitypes.array.Array1d",
+            "optional": false,
+            "group": null
+          }
+        },
+        "widget": {
+          "ctrl": {
+            "Title": "",
+            "Show Grid": true,
+            "X Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Y Axis": {
+              "Label": "",
+              "Log Scale": false
+            },
+            "Screenshots": {
+              "Record Screenshots": false,
+              "Screenshot Directory": "./screenshots"
+            },
+            "trace.0": "Projection.0.Out"
+          },
+          "legend": {
+            "trace.0": [
+              "Projection.0.Out",
+              "Projection.0.Out",
+              {
+                "Point": {
+                  "symbol": "None",
+                  "Brush": [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  "Size": 14
+                },
+                "Line": {
+                  "color": [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  "width": 1,
+                  "style": "Solid"
+                }
+              }
+            ]
+          },
+          "viewbox": {
+            "targetRange": [
+              [
+                -6.513660026440803,
+                1003.5038846056623
+              ],
+              [
+                610.6842706590096,
+                103204.2042152772
+              ]
+            ],
+            "viewRange": [
+              [
+                -6.513660026440803,
+                1003.5038846056623
+              ],
+              [
+                610.6842706590096,
+                103204.2042152772
+              ]
+            ],
+            "yInverted": false,
+            "xInverted": false,
+            "aspectLocked": false,
+            "autoRange": [
+              false,
+              false
+            ],
+            "autoPan": [
+              false,
+              false
+            ],
+            "autoVisibleOnly": [
+              false,
+              false
+            ],
+            "linkedViews": [
+              null,
+              null
+            ],
+            "defaultPadding": 0.02,
+            "mouseEnabled": [
+              true,
+              true
+            ],
+            "mouseMode": 3,
+            "enableMenu": false,
+            "wheelScaleFactor": -0.125,
+            "background": null,
+            "logMode": [
+              false,
+              false
+            ],
+            "limits": {
+              "xLimits": [
+                null,
+                null
+              ],
+              "yLimits": [
+                null,
+                null
+              ],
+              "xRange": [
+                null,
+                null
+              ],
+              "yRange": [
+                null,
+                null
+              ]
+            }
+          },
+          "screenshot_enabled": false,
+          "screenshot_dir": "./screenshots",
+          "screenshot_counter": 0
+        },
+        "geometry": "01d9d0cb00030000000009ec0000092c00000d0b00000c70000009ec0000095100000d0b00000c7000000002000000000f00000009ec0000095100000d0b00000c70"
+      }
+    }
+  ],
+  "connects": [
+    [
+      "manta:raw:value",
+      "Out",
+      "Roi2D.0",
+      "In"
+    ],
+    [
+      "step_value",
+      "Out",
+      "MeanVsScan.0",
+      "Bin"
+    ],
+    [
+      "step_value",
+      "Out",
+      "MeanVsScan.1",
+      "Bin"
+    ],
+    [
+      "Roi2D.0",
+      "Out",
+      "Projection.0",
+      "In"
+    ],
+    [
+      "Roi2D.0",
+      "Out",
+      "PythonEditor.0",
+      "In"
+    ],
+    [
+      "PythonEditor.0",
+      "Out",
+      "MeanVsScan.0",
+      "Value"
+    ],
+    [
+      "PythonEditor.0",
+      "Out.1",
+      "MeanVsScan.1",
+      "Value"
+    ],
+    [
+      "Projection.0",
+      "Out",
+      "WaveformViewer.0",
+      "In"
+    ],
+    [
+      "MeanVsScan.0",
+      "Bins",
+      "LinePlot.0",
+      "X"
+    ],
+    [
+      "MeanVsScan.0",
+      "Counts",
+      "LinePlot.0",
+      "Y"
+    ],
+    [
+      "MeanVsScan.1",
+      "Bins",
+      "LinePlot.1",
+      "X"
+    ],
+    [
+      "MeanVsScan.1",
+      "Counts",
+      "LinePlot.1",
+      "Y"
+    ]
+  ],
+  "viewbox": {
+    "comments": [
+      {
+        "id": 8,
+        "text": "Use source\nchannel",
+        "topLeft": [
+          0.0,
+          -300.0
+        ],
+        "bottomRight": [
+          100.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 9,
+        "text": "Average the \nregions with \nand without \nsignal",
+        "topLeft": [
+          400.0,
+          -300.0
+        ],
+        "bottomRight": [
+          500.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 10,
+        "text": "Integrate \naround \nsignal",
+        "topLeft": [
+          200.0,
+          -300.0
+        ],
+        "bottomRight": [
+          300.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 11,
+        "text": "Signal - Background",
+        "topLeft": [
+          600.0,
+          -300.0
+        ],
+        "bottomRight": [
+          700.0,
+          -200.0
+        ]
+      },
+      {
+        "id": 12,
+        "text": "Signal channel",
+        "topLeft": [
+          0.0,
+          200.0
+        ],
+        "bottomRight": [
+          100.0,
+          300.0
+        ]
+      },
+      {
+        "id": 15,
+        "text": "Pre IP (NORM)",
+        "topLeft": [
+          0.0,
+          -100.0
+        ],
+        "bottomRight": [
+          100.0,
+          0.0
+        ]
+      }
+    ]
+  },
+  "source_configuration": {
+    "type": "hdf5",
+    "interval": 0.01,
+    "init_time": 0.5,
+    "hb_period": 10,
+    "files": [],
+    "repeat": true
+  },
+  "library": {
+    "paths": []
+  }
+}

--- a/tests/graphs/threshold_detector.py
+++ b/tests/graphs/threshold_detector.py
@@ -1,0 +1,55 @@
+import typing
+
+import ami.graph_nodes as gn
+from ami.flowchart.Node import Node
+
+
+class EventProcessor:
+
+    def __init__(self):
+        pass
+
+    def begin_run(self):
+        pass
+
+    def end_run(self):
+        pass
+
+    def begin_step(self, step):
+        pass
+
+    def end_step(self, step):
+        pass
+
+    def on_event(self, In, *args, **kwargs):
+        In[In < 50] = 0
+        # return 1 output(s)
+        return In
+
+
+class threshold_detector(Node):
+    """ """
+
+    nodeName = "threshold_detector"
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "threshold": {"io": "out", "removable": True, "ttype": typing.Any, "optional": False, "group": None},
+                "In": {"io": "in", "removable": True, "ttype": typing.Any, "optional": False, "group": None},
+            },
+        )
+
+    def to_operation(self, **kwargs):
+        proc = EventProcessor()
+
+        return gn.Map(
+            name=self.name() + "_operation",
+            **kwargs,
+            func=proc.on_event,
+            begin_run=proc.begin_run,
+            end_run=proc.end_run,
+            begin_step=proc.begin_step,
+            end_step=proc.end_step,
+        )

--- a/tests/test_datasrc.py
+++ b/tests/test_datasrc.py
@@ -25,7 +25,7 @@ def sim_src_cfg():
             "delta_t": {"dtype": "Scalar", "range": [0, 10], "integer": True},
             "cspad": {"dtype": "Image", "pedestal": 5, "width": 1, "shape": [512, 512]},
             "acq": {"dtype": "Waveform", "pedestal": 5, "width": 1, "shape": 512},
-            "laser": {"dtype": "Scalar", "range": [0, 2], "integer": True},
+            "laser": {"dtype": "Scalar", "range": [0, 2], "integer": True, "binary": True},
         },
     }
 
@@ -998,10 +998,13 @@ def test_static_source(sim_src_cfg):
     for msg in source.events():
         if msg.mtype == MsgTypes.Datagram:
             for name, cfg in sim_src_cfg["config"].items():
+                is_binary = cfg.get("binary", False)
                 if cfg["dtype"] == "Scalar":
-                    assert msg.payload[name] == 1
+                    expected = (1 if count % 2 == 0 else 0) if is_binary else 1
+                    assert msg.payload[name] == expected
                 elif (cfg["dtype"] == "Image") or (cfg["dtype"] == "Waveform"):
-                    assert (msg.payload[name] == 1).all()
+                    expected = (1 if count % 2 == 0 else 0) if is_binary else 1
+                    assert (msg.payload[name] == expected).all()
             count += 1
             expected_ts = num_workers * count + idnum + sim_src_cfg["bound"]
             assert msg.timestamp == expected_ts

--- a/tests/test_graphcomm.py
+++ b/tests/test_graphcomm.py
@@ -76,7 +76,7 @@ class FakeManager:
 
 
 @pytest.fixture(scope="function")
-def graph_comm(request, ipc_dir, event_loop):
+def graph_comm(request, ipc_dir):
     ctxs = []
     name = "graph"
     addr = "ipc://%s/graphcomm_async" % ipc_dir

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -203,7 +203,11 @@ def extract_expected_features(fc_path):
 
 # Collect .fc files for parametrization
 _fc_files = sorted(glob.glob("tests/graphs/*.fc"))
-_xfail_files = {"XAS_HSD.fc"}
+_xfail_files = {"XAS_HSD.fc": "dict source type not mockable"}
+try:
+    import psana  # noqa: F401
+except ImportError:
+    _xfail_files["rad_integral.fc"] = "psana not available"
 
 
 @pytest.mark.asyncio
@@ -217,7 +221,7 @@ _xfail_files = {"XAS_HSD.fc"}
 async def test_fc_graph_smoke(qtbot, flowchart, start_ami, fc_file):
     """Load each .fc graph, apply to backend, verify it executes and produces expected features."""
     if Path(fc_file).name in _xfail_files:
-        pytest.xfail(f"{Path(fc_file).name}: dict source type not mockable")
+        pytest.xfail(f"{Path(fc_file).name}: {_xfail_files[Path(fc_file).name]}")
 
     fc, broker = flowchart
     comm = start_ami

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -208,6 +208,7 @@ try:
     import psana  # noqa: F401
 except ImportError:
     _xfail_files["rad_integral.fc"] = "psana not available"
+    _xfail_files["Rousseau.fc"] = "psana not available"
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,8 +7,10 @@ These tests verify complete user workflows:
 """
 
 import asyncio
+import glob
 import json
 import time
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -151,3 +153,112 @@ async def test_load_atm_crix_modify_save(qtbot, flowchart, tmp_path):
         assert "Projection.0" in node_names
         # Verify sources are still there
         assert any("timing:raw:eventcodes" in name for name in node_names)
+
+
+def extract_expected_features(fc_path):
+    """
+    Parse a .fc file to predict which _auto_* features should be produced.
+
+    Follows the naming logic in Node.connected() (Node.py:384-390):
+    - SourceNode upstream -> input_var is just the node name (no .Out suffix)
+    - Regular node upstream -> input_var is {node_name}.{terminal_name}
+    """
+    with open(fc_path) as f:
+        data = json.load(f)
+
+    # Build node class lookup
+    node_classes = {}
+    for node in data.get("nodes", []):
+        node_classes[node["name"]] = node["class"]
+
+    # Build connection map: {(to_node, to_term): (from_node, from_term)}
+    connections = {}
+    for conn in data.get("connects", []):
+        from_node, from_term, to_node, to_term = conn
+        connections[(to_node, to_term)] = (from_node, from_term)
+
+    expected = set()
+    for node in data.get("nodes", []):
+        state = node.get("state", {})
+        if not state.get("viewed", False):
+            continue
+
+        name = node["name"]
+        cls = node["class"]
+
+        if cls == "SourceNode":
+            expected.add(f"_auto_{name}")
+        else:
+            # Find input connections to this node
+            for (to_node, to_term), (from_node, from_term) in connections.items():
+                if to_node == name:
+                    from_cls = node_classes.get(from_node, "")
+                    if from_cls == "SourceNode":
+                        expected.add(f"_auto_{from_node}")
+                    else:
+                        expected.add(f"_auto_{from_node}.{from_term}")
+
+    return expected
+
+
+# Collect .fc files for parametrization
+_fc_files = sorted(glob.glob("tests/graphs/*.fc"))
+_xfail_files = {"XAS_HSD.fc"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flowchart", ["static"], indirect=True)
+@pytest.mark.parametrize("start_ami", ["static"], indirect=True)
+@pytest.mark.parametrize(
+    "fc_file",
+    _fc_files,
+    ids=lambda p: Path(p).stem,
+)
+async def test_fc_graph_smoke(qtbot, flowchart, start_ami, fc_file):
+    """Load each .fc graph, apply to backend, verify it executes and produces expected features."""
+    if Path(fc_file).name in _xfail_files:
+        pytest.xfail(f"{Path(fc_file).name}: dict source type not mockable")
+
+    fc, broker = flowchart
+    comm = start_ami
+    widget = fc.widget()
+    qtbot.addWidget(widget)
+
+    # Extract expected features from .fc file
+    expected_features = extract_expected_features(fc_file)
+
+    # Load and apply
+    await fc.loadFile(fc_file)
+
+    # Give views time to be registered
+    await asyncio.sleep(0.3)
+
+    # Wait for execution
+    start = time.time()
+    while comm.graphVersion != comm.featuresVersion:
+        await asyncio.sleep(0.1)
+        if time.time() - start > 15:
+            pytest.fail(f"Timeout: {Path(fc_file).name} did not execute")
+
+    assert comm.graphVersion > 0, f"{Path(fc_file).name}: graph not applied"
+
+    # Verify features exist
+    features = comm.features
+    assert features, f"{Path(fc_file).name}: no features produced"
+
+    # Check if any expected features were produced
+    # (Some may be missing due to filter conditions, non-viewable nodes, etc.)
+    found = expected_features & set(features.keys())
+
+    # If we expected features but none were produced, that's a real failure
+    if expected_features and not found:
+        pytest.fail(
+            f"{Path(fc_file).name}: none of the expected features found\n"
+            f"  Expected: {sorted(expected_features)}\n"
+            f"  Got: {sorted(features.keys())}"
+        )
+
+    # Fetch found features and verify they're not None
+    for feat_name in sorted(found):
+        result = comm.fetch(feat_name)
+        assert result is not None, f"{Path(fc_file).name}: feature {feat_name} returned None"


### PR DESCRIPTION
Add parametrized smoke test that loads each .fc file from tests/graphs/, applies it to the static backend, and verifies it executes without errors.

Changes:
- StaticSource: Alternate between 1/0 for binary-flagged sources (laser, eventcodes) so Filter nodes route events to different branches during tests
- fc_to_worker: Add BINARY_SOURCES set, auto-mark laser and eventcodes as binary
- test_integration: Add test_fc_graph_smoke with extract_expected_features() helper that predicts which _auto_* features should be produced from .fc files
- conftest: Add broker thread exception propagation to fail tests on broker crashes
- flowchart: Add KeyError guard in monitor_processes() for widget death race condition
- Mark laser as binary in config files and test fixtures
- Update test_static_source assertions to expect alternating values

8 files changed, 146 insertions(+), 10 deletions(-) Fixes widget subprocess crashes and enables automatic test coverage for new .fc files.