### PR TITLE
BUG Fix Array1D typo -- correct is Array1d.

### DIFF
--- a/ami/psana/epics.py
+++ b/ami/psana/epics.py
@@ -54,7 +54,7 @@ def lookup_epicstype(src, env):
         info = epics_store.getPV(src)
         if info is not None:
             if info.numElements() > 1:
-                return amitypes.Array1D
+                return amitypes.Array1d
             else:
                 return EPICS_TO_PYTHON.get(info.dbr().DBR_TYPE_ID.name)
 


### PR DESCRIPTION
There is a typo in a class name. This prevents CXI from running with AMI2 currently.