### PR TITLE
Add EPICS PVAccess ctrl interface for flowchart node parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,11 +354,13 @@ ami/
 ## Development Tips
 
 ### Adding New Graph Nodes
-1. **GUI Layer**: Create a class in `ami/flowchart/library/` that subclasses either `Node` or `CtrlNode`
+1. **GUI Layer**: Subclass `Node` or `CtrlNode`, add `nodeName` and a docstring, implement `to_operation()`
    - To define a node with a GUI, add a class variable `uiTemplate` that is parsed by `generateUi` in `WidgetGroup.py`
    - For custom widgets (e.g., plots), override the `display` method
-2. **Operation Layer**: Implement the `to_operation()` method to return an operation node from `ami/graph_nodes.py`
-3. **Testing**: Test with simple graph configuration
+2. **Registration**: Load your `.py` file via the **"Manage Library"** button in the flowchart toolbar — no need to edit the AMI package
+3. **Operation Layer**: Return the appropriate `ami/graph_nodes` type from `to_operation()` based on whether you need per-event transforms (`Map`) or distributed aggregation (`PickN`, `SumN`, `Accumulator`, `ReduceByKey`, `RollingBuffer`)
+4. **Testing**: Test with simple graph configuration
+- **See**: [Custom Node Implementation Guide](docs/CUSTOM_NODES.md) for full reference
 
 ### Debugging
 - Use `ami/forkedpdb.py` for multiprocess debugging

--- a/ami/client/flowchart.py
+++ b/ami/client/flowchart.py
@@ -308,6 +308,11 @@ class NodeProcess(QtCore.QObject):
                 self.node.terminalDisconnected(msg)
             elif isinstance(msg, fcMsgs.NodeLabelChanged):
                 self.updateWindowTitle(msg.label)
+            elif isinstance(msg, fcMsgs.NodeCtrlUpdate):
+                if hasattr(self.node, "stateGroup") and self.node.stateGroup is not None:
+                    self.node.blockSignals(True)
+                    self.node.stateGroup.setState(msg.parameters)
+                    self.node.blockSignals(False)
             elif isinstance(msg, fcMsgs.CloseNode):
                 return
 
@@ -654,6 +659,15 @@ class MessageBroker(object):
 
             elif isinstance(msg, fcMsgs.NodeLabelChanged):
                 await self.forward_message_to_node(topic, msg)
+
+            elif isinstance(msg, fcMsgs.NodeCtrlUpdate):
+                # Forward directly to the NodeProcess without caching — it's a
+                # transient update, not a "last state" message.
+                async with self.lock:
+                    running = topic in self.widget_procs
+                if running:
+                    await self.broker_pub_sock.send_string(topic + ZMQ_TOPIC_DELIM, zmq.SNDMORE)
+                    await self.broker_pub_sock.send_pyobj(msg)
 
             elif isinstance(msg, fcMsgs.CloseNode):
                 await self.forward_message_to_node(topic, msg)

--- a/ami/client/flowchart_messages.py
+++ b/ami/client/flowchart_messages.py
@@ -87,6 +87,20 @@ class NodeCheckpoint(NodeMsg):
         self.event = event
 
 
+class NodeCtrlUpdate(NodeMsg):
+    """Push a ctrl parameter update directly to a running NodeProcess window.
+
+    Sent by PvCtrlServer when an EPICS pvput changes a node parameter so the
+    visible spinbox/checkbox/combo in the NodeProcess window stays in sync.
+    The NodeProcess applies the update with blockSignals so no checkpoint is
+    echoed back to the flowchart.
+    """
+
+    def __init__(self, name, parameters):
+        super().__init__(name)
+        self.parameters = parameters  # {param: val} or {group: {param: val}}
+
+
 class NodeTermAdded(NodeMsg):
 
     def __init__(self, name, term, state):

--- a/ami/flowchart/Flowchart.py
+++ b/ami/flowchart/Flowchart.py
@@ -2310,7 +2310,7 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
     def _pvctrl_push_values(self, node=None):
         """Push current ctrl values to EPICS PVs when a node ctrl changes in the GUI."""
         if self.pvCtrlServer is not None:
-            self.pvCtrlServer.push_pv_values(self.chart)
+            self.pvCtrlServer.push_pv_values(node)
 
     @asyncSlot()
     async def applyClicked(self, build_views=True):

--- a/ami/flowchart/Flowchart.py
+++ b/ami/flowchart/Flowchart.py
@@ -31,6 +31,13 @@ try:
 except ImportError:
     HAS_QTCONSOLE = False
 
+try:
+    from ami.flowchart.PvCtrlServer import PvCtrlServer
+
+    HAS_PVCTRL = True
+except ImportError:
+    HAS_PVCTRL = False
+
 import asyncio
 import collections
 import itertools as it
@@ -2292,6 +2299,19 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
         self.graph_info = pc.Info("ami_graph", "AMI Client graph", ["hutch", "name"])
         self.graph_version = pc.Gauge("ami_graph_version", "AMI Client graph version", ["hutch", "name"])
 
+        if HAS_PVCTRL:
+            self.pvCtrlServer = PvCtrlServer(self.chart.hutch, self.graph_name, self)
+            self.pvCtrlServer.start()
+            self.chart.sigNodeChanged.connect(self._pvctrl_push_values)
+            QtWidgets.QApplication.instance().aboutToQuit.connect(self.pvCtrlServer.stop)
+        else:
+            self.pvCtrlServer = None
+
+    def _pvctrl_push_values(self, node=None):
+        """Push current ctrl values to EPICS PVs when a node ctrl changes in the GUI."""
+        if self.pvCtrlServer is not None:
+            self.pvCtrlServer.push_pv_values(self.chart)
+
     @asyncSlot()
     async def applyClicked(self, build_views=True):
         graph_nodes = []
@@ -2426,6 +2446,9 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
 
         self.graph_info.labels(self.chart.hutch, self.graph_name).info({"graph": state, "version": version})
         self.graph_version.labels(self.chart.hutch, self.graph_name).set(version)
+
+        if self.pvCtrlServer is not None:
+            self.pvCtrlServer.update_pvs(self.chart)
 
     def openClicked(self):
         startDir = self.chart.filePath

--- a/ami/flowchart/PvCtrlServer.py
+++ b/ami/flowchart/PvCtrlServer.py
@@ -1,0 +1,329 @@
+import asyncio
+import logging
+
+import zmq
+from p4p.nt import NTScalar
+from p4p.server import Server, StaticProvider
+from p4p.server.asyncio import SharedPV
+
+from ami import LogConfig
+from ami.client import flowchart_messages as fcMsgs
+
+logger = logging.getLogger(LogConfig.get_package_name(__name__))
+
+# Widget types that cannot be safely exposed as EPICS PVs
+_SKIP_TYPES = {"file_in", "file_out", "color"}
+
+# Mapping from uiTemplate widget type to p4p NTScalar type code
+_TYPE_TO_NT = {
+    "intSpin": "l",  # int64
+    "spin": "d",  # float64
+    "doubleSpin": "d",
+    "check": "?",  # bool
+    "combo": "s",  # string
+    "text": "s",
+}
+
+
+class _CtrlPutHandler:
+    """PUT handler for a single node ctrl parameter PV.
+
+    p4p's asyncio SharedPV delivers put() via loop.call_soon_threadsafe() which,
+    in qasync, routes through a Qt signal back into the main thread.  We are
+    therefore always running in the Qt main thread and can call GUI APIs directly.
+    """
+
+    def __init__(self, node, node_name, param, group, ptype, opts, chart):
+        self.node = node
+        self.node_name = node_name
+        self.param = param
+        self.group = group
+        self.ptype = ptype
+        self.opts = opts
+        self.chart = chart
+
+    def put(self, pv, op):
+        try:
+            raw = op.value()
+            val = raw["value"] if hasattr(raw, "__getitem__") else raw
+            val = self._validate(val)
+            # Post the new value so pvput/pvget see it before op.done() returns.
+            pv.post(val)
+            op.done()
+            # Direct GUI update — we are in the Qt main thread (see class docstring).
+            self._update_gui(val)
+        except Exception as e:
+            logger.error("PvCtrlServer PUT error for %s.%s: %s", self.node.name(), self.param, e)
+            op.done(error=str(e))
+
+    def _validate(self, val):
+        if self.ptype == "intSpin":
+            val = int(val)
+            if "min" in self.opts:
+                val = max(val, self.opts["min"])
+            if "max" in self.opts:
+                val = min(val, self.opts["max"])
+        elif self.ptype in ("doubleSpin", "spin"):
+            val = float(val)
+            if "min" in self.opts:
+                val = max(val, self.opts["min"])
+            if "max" in self.opts:
+                val = min(val, self.opts["max"])
+        elif self.ptype == "check":
+            val = bool(val)
+        else:
+            val = str(val)
+        return val
+
+    def _update_gui(self, val):
+        """Update the ctrl widget spinbox/checkbox/combo and mark the node changed.
+
+        Runs in the Qt main thread.  setState() fires sigStateChanged which triggers
+        refreshStatePanel so the inspector panel updates automatically.  sigNodeChanged
+        is emitted so the Apply button highlights green.
+
+        Also fires a NodeCtrlUpdate ZMQ message to any open NodeProcess window so the
+        visible spinbox there stays in sync with the pvput value.
+        """
+        try:
+            state = {self.group: {self.param: val}} if self.group else {self.param: val}
+            # setState calls setWidget → setValue, which fires valueChanged → sigChanged →
+            # state_changed → update() (updates node.values) + sigStateChanged (updates panel).
+            self.node.stateGroup.setState(state)
+            if self.node.isChanged(True, False):
+                self.node.changed = True
+                self.chart.sigNodeChanged.emit(self.node)
+            # Push to NodeProcess window if one is open for this node.
+            asyncio.ensure_future(self._push_to_node_process(state))
+        except Exception as e:
+            logger.error("PvCtrlServer GUI update error for %s.%s: %s", self.node.name(), self.param, e)
+
+    async def _push_to_node_process(self, params):
+        """Send NodeCtrlUpdate to a running NodeProcess so its ctrl window updates.
+
+        The broker forwards the message only when a NodeProcess is alive for this node.
+        The NodeProcess applies setState with blockSignals so no checkpoint echoes back.
+        """
+        try:
+            msg = fcMsgs.NodeCtrlUpdate(self.node_name, params)
+            await self.chart.broker.send_string(self.node_name, zmq.SNDMORE)
+            await self.chart.broker.send_pyobj(msg)
+        except Exception as e:
+            logger.debug("PvCtrlServer NodeCtrlUpdate send error for %s: %s", self.node_name, e)
+
+
+class _ApplyHandler:
+    """PUT/RPC handler for the apply trigger PV.
+
+    Like _CtrlPutHandler, called in the Qt main thread via p4p asyncio → qasync.
+    asyncio.ensure_future() is safe here because the asyncio loop is running.
+    """
+
+    def __init__(self, ctrl_widget):
+        self.ctrl_widget = ctrl_widget
+
+    def put(self, pv, op):
+        try:
+            pv.post(0)
+            op.done()
+            asyncio.ensure_future(self.ctrl_widget.applyClicked())
+        except Exception as e:
+            logger.error("PvCtrlServer apply PUT error: %s", e)
+            op.done(error=str(e))
+
+    def rpc(self, pv, op):
+        try:
+            op.done()
+            asyncio.ensure_future(self.ctrl_widget.applyClicked())
+        except Exception as e:
+            logger.error("PvCtrlServer apply RPC error: %s", e)
+            op.done(error=str(e))
+
+
+class _SharedPVHandler:
+    """Thin wrapper that holds both a put and an rpc callable, matching p4p's handler protocol."""
+
+    def __init__(self, put=None, rpc=None):
+        self._put = put
+        self._rpc = rpc
+
+    def put(self, pv, op):
+        if self._put is not None:
+            self._put(pv, op)
+
+    def rpc(self, pv, op):
+        if self._rpc is not None:
+            self._rpc(pv, op)
+
+
+class PvCtrlServer:
+    """
+    Hosts writable EPICS PVs (PVAccess) for all uiTemplate ctrl parameters of every
+    parameterised node in the flowchart graph.
+
+    PV naming::
+
+        {prefix}:ctrl:{graph_name}:{NodeName.instance}:{param_name}
+        {prefix}:ctrl:{graph_name}:apply
+
+    where ``prefix = "{hutch}:ami"`` when hutch is set, otherwise ``"ami"``.
+
+    Grouped uiTemplate fields use ``{group}__{param}`` as the final PV name component.
+
+    Workflow
+    --------
+    1. Write to one or more param PVs — the GUI ctrl widgets update and the Apply
+       button highlights green, but the running graph is *not* changed yet.
+    2. Write any value to the ``apply`` PV (or issue a PVA RPC call on it) to fire
+       ``applyClicked()`` and push the new parameters to the running graph.
+    """
+
+    def __init__(self, hutch, graph_name, ctrl_widget):
+        self.prefix = f"{hutch}:ami" if hutch else "ami"
+        self.graph_name = graph_name
+        self.ctrl_widget = ctrl_widget
+        self.chart = ctrl_widget.chart
+        self.provider = None
+        self.server = None
+        self.pvs = {}  # {full_pv_name: SharedPV}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self):
+        self.provider = StaticProvider(f"ami_ctrl_{self.graph_name}")
+        self.server = Server(providers=[self.provider])
+        logger.info(
+            "PvCtrlServer started — base prefix: %s:ctrl:%s",
+            self.prefix,
+            self.graph_name,
+        )
+
+    def stop(self):
+        if self.server is not None:
+            self.server.stop()
+            self.server = None
+        self.pvs.clear()
+        logger.info("PvCtrlServer stopped")
+
+    # ------------------------------------------------------------------
+    # Public update methods (called from FlowchartCtrlWidget)
+    # ------------------------------------------------------------------
+
+    def update_pvs(self, chart):
+        """Diff the current node set against hosted PVs; create/update/remove as needed.
+
+        Called at the end of every ``applyClicked()``.
+        """
+        if self.provider is None:
+            return
+
+        wanted = {}  # {pv_name: (node, param, group, ptype, opts)}
+        for node_name, node in chart._graph.nodes(data="node"):
+            if node is None:
+                continue
+            if not hasattr(node, "stateGroup") or node.stateGroup is None:
+                continue
+            for param, group, ptype, opts in self._iter_node_params(node):
+                pv_name = self._param_pv_name(node_name, param, group)
+                wanted[pv_name] = (node, param, group, ptype, opts)
+
+        apply_name = self._apply_pv_name()
+
+        # Remove PVs for deleted nodes
+        for pv_name in list(self.pvs.keys()):
+            if pv_name == apply_name:
+                continue
+            if pv_name not in wanted:
+                self.provider.remove(pv_name)
+                del self.pvs[pv_name]
+                logger.debug("Removed ctrl PV: %s", pv_name)
+
+        # Create new PVs or post updated values to existing ones
+        for pv_name, (node, param, group, ptype, opts) in wanted.items():
+            cur_val = self._current_value(node, param, group)
+            if cur_val is None:
+                continue
+            nt = NTScalar(_TYPE_TO_NT[ptype])
+            if pv_name not in self.pvs:
+                handler = _CtrlPutHandler(node, node_name, param, group, ptype, opts, self.chart)
+                pv = SharedPV(nt=nt, initial=cur_val, handler=_SharedPVHandler(put=handler.put))
+                self.provider.add(pv_name, pv)
+                self.pvs[pv_name] = pv
+                logger.debug("Created ctrl PV: %s = %r", pv_name, cur_val)
+            else:
+                self.pvs[pv_name].post(cur_val)
+
+        # Create the apply PV once any parameterised node exists
+        if apply_name not in self.pvs and wanted:
+            apply_handler = _ApplyHandler(self.ctrl_widget)
+            apply_pv = SharedPV(
+                nt=NTScalar("i"),
+                initial=0,
+                handler=_SharedPVHandler(put=apply_handler.put, rpc=apply_handler.rpc),
+            )
+            self.provider.add(apply_name, apply_pv)
+            self.pvs[apply_name] = apply_pv
+            logger.debug("Created apply PV: %s", apply_name)
+        elif apply_name in self.pvs and not wanted:
+            # All parameterised nodes removed — tear down the apply PV too
+            self.provider.remove(apply_name)
+            del self.pvs[apply_name]
+
+    def push_pv_values(self, chart):
+        """Post current ctrl values to PVs so EPICS readers stay in sync with the GUI.
+
+        Called on ``sigNodeChanged`` (a ctrl was changed in the GUI but Apply has not
+        been clicked yet).
+        """
+        if self.provider is None:
+            return
+        for node_name, node in chart._graph.nodes(data="node"):
+            if node is None:
+                continue
+            if not hasattr(node, "stateGroup") or node.stateGroup is None:
+                continue
+            for param, group, _ptype, _opts in self._iter_node_params(node):
+                pv_name = self._param_pv_name(node_name, param, group)
+                if pv_name not in self.pvs:
+                    continue
+                val = self._current_value(node, param, group)
+                if val is not None:
+                    self.pvs[pv_name].post(val)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _param_pv_name(self, node_name, param, group=None):
+        parts = [self.prefix, "ctrl", self.graph_name, node_name]
+        parts.append(f"{group}__{param}" if group else param)
+        return ":".join(parts)
+
+    def _apply_pv_name(self):
+        return ":".join([self.prefix, "ctrl", self.graph_name, "apply"])
+
+    @staticmethod
+    def _iter_node_params(node):
+        """Yield ``(param, group_or_None, ptype, opts)`` for each exposable ctrl field."""
+        ui_template = getattr(node.__class__, "uiTemplate", None)
+        if not ui_template:
+            return
+        for entry in ui_template:
+            if len(entry) == 2:
+                k, t = entry
+                o = {}
+            elif len(entry) == 3:
+                k, t, o = entry
+            else:
+                continue
+            if t in _SKIP_TYPES or t not in _TYPE_TO_NT:
+                continue
+            yield k, o.get("group"), t, o
+
+    @staticmethod
+    def _current_value(node, param, group):
+        if group:
+            return node.values.get(group, {}).get(param)
+        return node.values.get(param)

--- a/ami/flowchart/PvCtrlServer.py
+++ b/ami/flowchart/PvCtrlServer.py
@@ -271,26 +271,25 @@ class PvCtrlServer:
             self.provider.remove(apply_name)
             del self.pvs[apply_name]
 
-    def push_pv_values(self, chart):
+    def push_pv_values(self, node):
         """Post current ctrl values to PVs so EPICS readers stay in sync with the GUI.
 
-        Called on ``sigNodeChanged`` (a ctrl was changed in the GUI but Apply has not
-        been clicked yet).
+        Called on ``sigNodeChanged`` with the specific node that changed.
+        Only that node's PVs are updated — ``update_pvs`` handles the full
+        graph when Apply is clicked.
         """
-        if self.provider is None:
+        if self.provider is None or node is None:
             return
-        for node_name, node in chart._graph.nodes(data="node"):
-            if node is None:
+        if not hasattr(node, "stateGroup") or node.stateGroup is None:
+            return
+        node_name = node.name()
+        for param, group, _ptype, _opts in self._iter_node_params(node):
+            pv_name = self._param_pv_name(node_name, param, group)
+            if pv_name not in self.pvs:
                 continue
-            if not hasattr(node, "stateGroup") or node.stateGroup is None:
-                continue
-            for param, group, _ptype, _opts in self._iter_node_params(node):
-                pv_name = self._param_pv_name(node_name, param, group)
-                if pv_name not in self.pvs:
-                    continue
-                val = self._current_value(node, param, group)
-                if val is not None:
-                    self.pvs[pv_name].post(val)
+            val = self._current_value(node, param, group)
+            if val is not None:
+                self.pvs[pv_name].post(val)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/docs/CUSTOM_NODES.md
+++ b/docs/CUSTOM_NODES.md
@@ -1,0 +1,908 @@
+# Custom Node Implementation Guide
+
+Reference for implementing custom GUI nodes in the AMI flowchart system.
+Covers the full stack: GUI layer → `to_operation()` → `graph_nodes` execution → display widgets.
+
+---
+
+## Table of Contents
+
+1. [Quick Decision Maps](#1-quick-decision-maps)
+2. [Node Anatomy](#2-node-anatomy)
+3. [uiTemplate Reference](#3-uitemplate-reference)
+4. [to_operation() Patterns](#4-to_operation-patterns)
+5. [Display Integration](#5-display-integration)
+6. [Key Invariants and Gotchas](#6-key-invariants-and-gotchas)
+7. [Registration via Manage Library](#7-registration-via-manage-library)
+8. [EPICS Ctrl Interface](#8-epics-ctrl-interface)
+
+---
+
+## 1. Quick Decision Maps
+
+### Which `graph_nodes` type to use in `to_operation()`?
+
+| Requirement | Node type | `global_op` flag |
+|---|---|---|
+| Pure per-shot function, no state | `gn.Map` | False |
+| Make any value viewable / latest value | `gn.PickN(N=1)` | True |
+| Collect N sequential samples as a list | `gn.PickN(N>1)` | True |
+| Sum N frames numerically (numpy) | `gn.SumN` | True |
+| Sliding window of last N values (continuous) | `gn.RollingBuffer` | True |
+| Aggregate by a categorical key | `gn.ReduceByKey` | True |
+| Custom multi-tier accumulation | `gn.Accumulator` | True |
+
+**Rule of thumb:** anything that needs to aggregate across events or across workers is a `GlobalTransformation` → set `global_op=True` on the node and use one of the global graph node types.
+
+### Which node flags to set?
+
+| Flag | When to set | Effect |
+|---|---|---|
+| `global_op=True` | Any node returning a `GlobalTransformation` | Renders blue; adds "Latch Outputs" context menu |
+| `viewable=True` | Node that only subscribes to an upstream value (no `to_operation`) | Manager publishes the input; `AsyncFetcher` requests it directly |
+| `buffered=True` | Node whose `to_operation` emits buffer outputs for display | Uses `buffered_topics()`/`buffered_terms()` for subscription |
+| `exportable=True` | Node that exports data via the export service | `graphCommHandler.export()` is called on build_views |
+| `allowAddInput=True` | Node that accepts a variable number of inputs | Adds "Add input" to context menu |
+
+---
+
+## 2. Node Anatomy
+
+### Base class hierarchy
+
+```
+Node                    (ami/flowchart/Node.py:29)
+└── CtrlNode            (ami/flowchart/library/common.py:16)
+    ├── SourceNode      (common.py:147)   — data source, viewable=True, no to_operation
+    └── GroupedNode     (common.py:199)   — matched input/output terminal pairs
+```
+
+**Use `Node`** when there are no user-configurable parameters (no `uiTemplate` needed).
+**Use `CtrlNode`** for everything else — it wires `uiTemplate` into `self.ctrls`/`self.values` automatically.
+
+### Required class attributes
+
+```python
+class MyNode(CtrlNode):
+    """One-line description of what this node does."""  # REQUIRED — used by NodeLibrary
+    nodeName = "MyNode"                                 # REQUIRED — serialized in .fc files
+```
+
+Both are mandatory. `isNodeClass()` rejects classes missing `nodeName`; `getLabelTree()` asserts a docstring exists.
+
+### Terminal definitions
+
+```python
+terminals = {
+    "TermName": {
+        "io": "in",           # REQUIRED: "in" or "out"
+        "ttype": float,       # REQUIRED: type annotation
+        "removable": True,    # optional
+        "optional": True,     # optional
+        "group": "grp_name",  # optional — pairs terminals into a named group
+    }
+}
+```
+
+**Common `ttype` values:**
+
+| Type | Meaning |
+|---|---|
+| `float`, `int`, `bool` | Scalar |
+| `str` | String |
+| `typing.Any` | Any type |
+| `amitypes.Array1d` | 1D numpy array |
+| `amitypes.Array2d` | 2D numpy array |
+| `amitypes.Array3d` | 3D numpy array |
+| `amitypes.Array` | Any numpy array |
+| `amitypes.MultiChannelWaveform` | Multi-channel waveform |
+| `dict` | Python dict |
+| `typing.Union[float, Array1d]` | Union type |
+
+### Constructor pattern
+
+```python
+def __init__(self, name):
+    super().__init__(
+        name,
+        terminals={
+            "In":  {"io": "in",  "ttype": Array1d},
+            "Out": {"io": "out", "ttype": Array1d},
+        },
+        global_op=True,   # set if to_operation returns a GlobalTransformation
+    )
+```
+
+### `to_operation()` signature
+
+Called by the flowchart on Apply with these kwargs:
+
+```python
+def to_operation(self, inputs, outputs, **kwargs):
+    # inputs:  dict {term_name: variable_name_str}
+    #          e.g. {"In": "SomeSource.0.Out"}
+    # outputs: list [variable_name_str, ...]
+    #          e.g. ["MyNode.0.Out"]
+    # kwargs always contains: parent (str), latched (bool)
+    # — pass **kwargs through to every gn.* constructor
+```
+
+Returns either a single `gn.*` node or a list of `gn.*` nodes (for multi-stage pipelines).
+
+### `isChanged()` — when does `.fc` restore trigger graph resubmit?
+
+```python
+def isChanged(self, restore_ctrl, restore_widget):
+    return False                        # viewer-only nodes (no to_operation)
+    return restore_ctrl                 # ctrl values parameterize to_operation (most nodes)
+    return restore_widget               # widget state parameterizes to_operation (code editors)
+    return restore_ctrl or restore_widget  # default CtrlNode behavior
+```
+
+---
+
+## 3. `uiTemplate` Reference
+
+Defined as a class-level list; parsed by `generateUi()` in `ami/flowchart/library/WidgetGroup.py:439`.
+
+```python
+uiTemplate = [
+    ("field_name", "widget_type"),
+    ("field_name", "widget_type", {options}),
+]
+```
+
+After `__init__`, the values are accessible as `self.values["field_name"]` and the widget as `self.ctrls["field_name"]`.
+
+### Widget types
+
+| Type string | Qt widget | Key options |
+|---|---|---|
+| `"intSpin"` | `QSpinBox` | `value` (int), `min`, `max` |
+| `"doubleSpin"` | `ScientificDoubleSpinBox` | `value` (float), `min`, `max` |
+| `"spin"` | pyqtgraph `SpinBox` | any pyqtgraph SpinBox opts |
+| `"check"` | `QCheckBox` | `checked` (bool) |
+| `"combo"` | `QComboBox` | `values` (list), `value` (initial) |
+| `"color"` | pyqtgraph `ColorButton` | `value` (RGB tuple) |
+| `"text"` | `QLineEdit` | `value` (str), `placeholder` (str) |
+| `"file_in"` | `PushButtonSelectFile` | `value` (path str) |
+| `"file_out"` | `PushButtonSelectFile` | `value` (path str) |
+
+**Cross-cutting options** (any widget type):
+- `"tip"` — tooltip string
+- `"hidden"` — bool, hides the row initially
+- `"group"` — str, wraps in a `QGroupBox`; creates `self.values[group][field]` and `self.ctrls[group][field]`
+
+### Accessing values in `to_operation()`
+
+```python
+# Direct field
+n = self.values["N"]
+
+# Grouped field
+label = self.values["X Axis"]["Label"]
+```
+
+### Reacting to ctrl changes (dynamic terminals)
+
+Override `state_changed()` to add/remove terminals when a checkbox toggles:
+
+```python
+def state_changed(self, *args, **kwargs):
+    super().state_changed(*args, **kwargs)
+    name, group, val = args[0], args[1], args[2]
+    if name == "weighted" and val:
+        self.addTerminal("Weights", io="in", ttype=float)
+    elif name == "weighted" and not val:
+        self.removeTerminal("Weights")
+```
+
+### Setting ctrl values programmatically (without triggering signal loops)
+
+```python
+self.stateGroup.blockSignals(True)
+self.ctrls["field"].setValue(new_value)
+self.stateGroup.blockSignals(False)
+```
+
+---
+
+## 4. `to_operation()` Patterns
+
+### Pattern A — Simple Map (no UI, Node base)
+
+Use for: pure per-shot transform, no user parameters, no state.
+
+```python
+import ami.graph_nodes as gn
+from amitypes import Array1d
+from ami.flowchart.Node import Node
+
+
+class Abs1D(Node):
+    """Element-wise absolute value of a 1D array."""
+    nodeName = "Abs1D"
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":  {"io": "in",  "ttype": Array1d},
+                "Out": {"io": "out", "ttype": Array1d},
+            },
+        )
+
+    def to_operation(self, **kwargs):
+        return gn.Map(name=self.name() + "_operation", **kwargs, func=lambda a: abs(a))
+```
+
+### Pattern B — Parametric Map (CtrlNode + uiTemplate)
+
+Use for: per-shot transform with user-configurable parameters. Ctrl values are captured in the closure at compile time.
+
+```python
+import numpy as np
+import ami.graph_nodes as gn
+from amitypes import Array1d
+from ami.flowchart.library.common import CtrlNode
+
+
+class Threshold1D(CtrlNode):
+    """Zero values below threshold in a 1D array."""
+    nodeName = "Threshold1D"
+    uiTemplate = [
+        ("threshold", "doubleSpin", {"value": 0.0}),
+        ("invert",    "check",      {"checked": False}),
+    ]
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":  {"io": "in",  "ttype": Array1d},
+                "Out": {"io": "out", "ttype": Array1d},
+            },
+        )
+
+    def to_operation(self, **kwargs):
+        threshold = self.values["threshold"]   # captured at compile time
+        invert    = self.values["invert"]
+
+        def func(arr):
+            mask = arr < threshold if not invert else arr >= threshold
+            result = arr.copy()
+            result[mask] = 0
+            return result
+
+        return gn.Map(name=self.name() + "_operation", **kwargs, func=func)
+```
+
+### Pattern C — PickN → Map (collect N, then compute)
+
+Use for: any computation that needs N samples before producing a result (frame average, statistics over a batch).
+Requires `global_op=True`.
+
+```python
+import numpy as np
+import ami.graph_nodes as gn
+from amitypes import Array2d
+from ami.flowchart.library.common import CtrlNode
+
+
+class FrameAverage(CtrlNode):
+    """Collect N frames and compute their pixel-wise mean."""
+    nodeName = "FrameAverage"
+    uiTemplate = [("N", "intSpin", {"value": 10, "min": 2})]
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":  {"io": "in",  "ttype": Array2d},
+                "Out": {"io": "out", "ttype": Array2d},
+            },
+            global_op=True,
+        )
+
+    def to_operation(self, inputs, outputs, **kwargs):
+        collected = [self.name() + "_collected"]
+
+        return [
+            gn.PickN(
+                name=self.name() + "_pick",
+                N=self.values["N"],
+                inputs=inputs,
+                outputs=collected,
+                **kwargs,
+            ),
+            gn.Map(
+                name=self.name() + "_mean",
+                inputs=collected,
+                outputs=outputs,
+                func=lambda frames: np.mean(frames, axis=0),
+                **kwargs,
+            ),
+        ]
+```
+
+**Gotcha:** `PickN` returns `None` until N samples are collected. The downstream `Map` is only called when `PickN` fires, so this is handled automatically — but any `Map` that directly consumes a `PickN` output must not assume the value is always present.
+
+### Pattern D — SumN → Map (sum N frames, then normalize)
+
+Use for: numeric sum of N shots (e.g., improve SNR on array detectors). Simpler than `Accumulator` but hardcoded to `np.add`.
+`SumN` always produces **2 outputs**: `(count, sum)`.
+
+```python
+import ami.graph_nodes as gn
+from amitypes import Array2d
+from ami.flowchart.library.common import CtrlNode
+
+
+class SumFrames(CtrlNode):
+    """Sum N detector frames."""
+    nodeName = "SumFrames"
+    uiTemplate = [("N", "intSpin", {"value": 10, "min": 2})]
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":    {"io": "in",  "ttype": Array2d},
+                "Sum":   {"io": "out", "ttype": Array2d},
+                "Count": {"io": "out", "ttype": int},
+            },
+            global_op=True,
+        )
+
+    def to_operation(self, inputs, outputs, **kwargs):
+        # SumN outputs are always [count_var, sum_var] — note the order
+        sum_outputs = [self.name() + "_count", self.name() + "_sum"]
+
+        def split(count, total):
+            return total, count
+
+        return [
+            gn.SumN(
+                name=self.name() + "_sumN",
+                N=self.values["N"],
+                inputs=inputs,
+                outputs=sum_outputs,
+                **kwargs,
+            ),
+            gn.Map(
+                name=self.name() + "_split",
+                inputs=sum_outputs,
+                outputs=outputs,
+                func=split,
+                **kwargs,
+            ),
+        ]
+```
+
+### Pattern E — Accumulator (infinite or custom reduction)
+
+Use for: custom multi-tier accumulation that doesn't fit PickN/SumN — running mean, variance, custom histograms, anything requiring user-supplied logic.
+`Accumulator` also always produces **2 outputs**: `(count, result)`.
+
+The reduction signature is: `reduction(res, *values, count=count, reset=reset)` where `reset=True` on the first call after a heartbeat boundary.
+
+```python
+import numpy as np
+import ami.graph_nodes as gn
+from amitypes import Array1d
+from ami.flowchart.library.common import CtrlNode
+
+
+class RunningMean1D(CtrlNode):
+    """Continuously accumulate a running mean of 1D arrays."""
+    nodeName = "RunningMean1D"
+    uiTemplate = []
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":  {"io": "in",  "ttype": Array1d},
+                "Out": {"io": "out", "ttype": Array1d},
+            },
+            global_op=True,
+        )
+
+    def to_operation(self, inputs, outputs, **kwargs):
+        acc_outputs = [self.name() + "_count", self.name() + "_sum"]
+
+        def reduction(res, arr, count=1, reset=False):
+            if reset:
+                return arr
+            return res + arr
+
+        def normalize(count, total):
+            return total / count
+
+        return [
+            gn.Accumulator(
+                name=self.name() + "_acc",
+                inputs=inputs,
+                outputs=acc_outputs,
+                res_factory=lambda: 0,
+                reduction=reduction,
+                **kwargs,
+            ),
+            gn.Map(
+                name=self.name() + "_norm",
+                inputs=acc_outputs,
+                outputs=outputs,
+                func=normalize,
+                **kwargs,
+            ),
+        ]
+```
+
+**Worker/local/global reductions:** If you need different logic at each tier, pass `worker_reduction`, `local_reduction`, `global_reduction` separately instead of a single `reduction`.
+
+### Pattern F — ReduceByKey → Map (bin by key, post-process)
+
+Use for: aggregating by a categorical label (scan step index, detector channel, etc.).
+Output is a `dict {key: accumulated_value}`.
+
+```python
+import numpy as np
+import ami.graph_nodes as gn
+from ami.flowchart.library.common import CtrlNode
+
+
+class MeanByBin(CtrlNode):
+    """Compute per-bin mean of a scalar keyed by an integer bin index."""
+    nodeName = "MeanByBin"
+    uiTemplate = []
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "Key":    {"io": "in",  "ttype": int},
+                "Value":  {"io": "in",  "ttype": float},
+                "Result": {"io": "out", "ttype": dict},
+            },
+            global_op=True,
+        )
+
+    def to_operation(self, inputs, outputs, **kwargs):
+        reduce_outputs = [self.name() + "_reduced"]
+
+        # reduction receives (current_value, new_value) per key
+        # accumulate (sum, count) tuples
+        def reduction(cur, val):
+            return (cur[0] + val[0], cur[1] + val[1])
+
+        # map raw inputs to (value, 1) before keying
+        map_outputs = [self.name() + "_key", self.name() + "_pair"]
+
+        def make_pair(k, v):
+            return k, (v, 1)
+
+        def compute_means(d):
+            return {k: v[0] / v[1] for k, v in d.items()}
+
+        return [
+            gn.Map(
+                name=self.name() + "_pair_map",
+                inputs=inputs,
+                outputs=map_outputs,
+                func=make_pair,
+                **kwargs,
+            ),
+            gn.ReduceByKey(
+                name=self.name() + "_reduce",
+                inputs=map_outputs,
+                outputs=reduce_outputs,
+                reduction=reduction,
+                **kwargs,
+            ),
+            gn.Map(
+                name=self.name() + "_means",
+                inputs=reduce_outputs,
+                outputs=outputs,
+                func=compute_means,
+                **kwargs,
+            ),
+        ]
+```
+
+### Pattern G — RollingBuffer → Map (for buffered=True display nodes)
+
+Use for: any node that maintains a sliding window of recent values for display (scatter plots, time-series). Use `buffered=True` on the node.
+`RollingBuffer` always produces **2 outputs**: `(count, buffer_list)`.
+
+```python
+import ami.graph_nodes as gn
+from amitypes import Array1d
+from ami.flowchart.library.common import CtrlNode
+from ami.flowchart.library.DisplayWidgets import ScatterWidget
+
+
+class ScatterBuffer(CtrlNode):
+    """Plot X vs Y from a rolling buffer of N events."""
+    nodeName = "ScatterBuffer"
+    uiTemplate = [("N", "intSpin", {"value": 100, "min": 1})]
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "X": {"io": "in", "ttype": float},
+                "Y": {"io": "in", "ttype": float},
+            },
+            buffered=True,
+        )
+
+    def isChanged(self, restore_ctrl, restore_widget):
+        return restore_ctrl
+
+    def display(self, topics, terms, addr, win, **kwargs):
+        return super().display(topics, terms, addr, win, ScatterWidget, **kwargs)
+
+    def to_operation(self, inputs, outputs, **kwargs):
+        # outputs must be keyed by input terminal name for buffered nodes
+        outputs = [self.name() + "." + k for k in inputs.keys()]
+        buf_outputs = [self.name() + "_count", self.name() + "_buf"]
+
+        return [
+            gn.RollingBuffer(
+                name=self.name() + "_buffer",
+                N=self.values["N"],
+                inputs=inputs,
+                outputs=buf_outputs,
+                **kwargs,
+            ),
+            gn.Map(
+                name=self.name() + "_unzip",
+                inputs=buf_outputs,
+                outputs=outputs,
+                func=lambda count, buf: zip(*buf),
+                **kwargs,
+            ),
+        ]
+```
+
+### Pattern H — Map pre-processing → GlobalTransformation → Map post-processing
+
+Use for: any pipeline where raw inputs need reshaping before the global accumulation step, and results need reshaping after.
+
+```python
+import numpy as np
+import ami.graph_nodes as gn
+from amitypes import Array1d
+from ami.flowchart.library.common import CtrlNode
+
+
+class NormalizedSumN(CtrlNode):
+    """Sum N arrays and normalize by the max value."""
+    nodeName = "NormalizedSumN"
+    uiTemplate = [("N", "intSpin", {"value": 10, "min": 2})]
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":  {"io": "in",  "ttype": Array1d},
+                "Out": {"io": "out", "ttype": Array1d},
+            },
+            global_op=True,
+        )
+
+    def to_operation(self, inputs, outputs, **kwargs):
+        pre_outputs  = [self.name() + "_float"]
+        sum_outputs  = [self.name() + "_count", self.name() + "_sum"]
+
+        return [
+            # Pre-processing Map: cast to float32 before accumulating
+            gn.Map(
+                name=self.name() + "_cast",
+                inputs=inputs,
+                outputs=pre_outputs,
+                func=lambda a: a.astype(np.float32),
+                **kwargs,
+            ),
+            gn.SumN(
+                name=self.name() + "_sumN",
+                N=self.values["N"],
+                inputs=pre_outputs,
+                outputs=sum_outputs,
+                **kwargs,
+            ),
+            # Post-processing Map: normalize after accumulation
+            gn.Map(
+                name=self.name() + "_norm",
+                inputs=sum_outputs,
+                outputs=outputs,
+                func=lambda count, total: total / (total.max() or 1),
+                **kwargs,
+            ),
+        ]
+```
+
+---
+
+## 5. Display Integration
+
+### Option 1 — `viewable=True` (subscribe to upstream, no `to_operation`)
+
+The node subscribes to an already-computed upstream variable. The manager publishes it on each heartbeat; the display widget requests it on demand.
+
+```python
+from amitypes import Array1d
+from ami.flowchart.library.common import CtrlNode
+from ami.flowchart.library.DisplayWidgets import WaveformWidget
+
+
+class WaveformMonitor(CtrlNode):
+    """Monitor a 1D waveform in real time."""
+    nodeName = "WaveformMonitor"
+    uiTemplate = []
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={"In": {"io": "in", "ttype": Array1d}},
+            viewable=True,
+        )
+
+    def isChanged(self, restore_ctrl, restore_widget):
+        return False   # viewer nodes never trigger graph resubmit
+
+    def display(self, topics, terms, addr, win, **kwargs):
+        return super().display(topics, terms, addr, win, WaveformWidget, **kwargs)
+```
+
+### Option 2 — `buffered=True` (node produces buffer outputs, display subscribes to those)
+
+The node has a `to_operation()` that emits buffer outputs (e.g., via `RollingBuffer`). The display subscribes to those buffer variable names directly. See Pattern G above.
+
+### Choosing a display widget
+
+| Data shape | Widget class |
+|---|---|
+| Single `float`/`int` | `ScalarWidget` |
+| Any Python object (str representation) | `ObjectWidget` |
+| `Array1d` — one or multiple traces | `WaveformWidget` |
+| 2D array of lines | `MultiWaveformWidget` |
+| `Array2d` — image | `ImageWidget` |
+| `Array2d` — image + click cursor | `PixelDetWidget` |
+| `(bins, counts)` — 1D histogram | `HistogramWidget` |
+| `(xbins, ybins, counts)` — 2D histogram | `Histogram2DWidget` |
+| `(X, Y)` — scatter | `ScatterWidget` |
+| `(X, Y)` — sorted line | `LineWidget` |
+| `(X, Y)` — time-series (date axis) | `TimeWidget` |
+| Binary event lanes | `CategoryWidget` |
+
+All widget classes are in `ami/flowchart/library/DisplayWidgets.py`.
+
+### Custom display widget
+
+Use when none of the standard widgets fit.
+
+```python
+from qtpy import QtWidgets
+import pyqtgraph as pg
+from ami.flowchart.library.DisplayWidgets import AsyncFetcher
+
+
+class MyWidget(QtWidgets.QWidget):
+    def __init__(self, topics, terms, addr, parent=None, **kwargs):
+        super().__init__(parent)
+        self.node = kwargs.get("node", None)
+
+        # AsyncFetcher subscribes to heartbeats and fetches data on each one
+        self.fetcher = None
+        if addr:
+            self.fetcher = AsyncFetcher(topics, terms, addr, parent=self)
+            self.fetcher.start()
+
+        # Build UI
+        self.label = QtWidgets.QLabel("waiting...", parent=self)
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.label)
+        self.setLayout(layout)
+
+    def update(self):
+        # Called on each heartbeat by AsyncFetcher signal
+        while self.fetcher.ready:
+            heartbeat_timestamp, reply = self.fetcher.reply
+            # reply = {input_term_name: value}
+            for k, v in reply.items():
+                self.label.setText(str(v))
+
+    def saveState(self):
+        return {}   # return dict of serializable state
+
+    def restoreState(self, state):
+        pass
+
+    def close(self):
+        if self.fetcher:
+            self.fetcher.close()   # REQUIRED — must close fetcher on widget close
+```
+
+Then in the node:
+
+```python
+def display(self, topics, terms, addr, win, **kwargs):
+    if self.widget is None:
+        self.widget = MyWidget(topics, terms, addr, parent=win, node=self, **kwargs)
+    return self.widget
+```
+
+### Bidirectional coupling (interactive overlays that update ctrls)
+
+When a plot overlay (e.g., a draggable ROI) should update the node's ctrl values and trigger a graph resubmit, use this pattern:
+
+```python
+def display(self, topics, terms, addr, win, **kwargs):
+    super().display(topics, terms, addr, win, ImageWidget, **kwargs)
+    if self.widget:
+        self.roi = pg.RectROI([ox, oy], [ex, ey])
+        self.roi.sigRegionChangeFinished.connect(self._roi_moved)
+        self.widget.view.addItem(self.roi)
+    return self.widget
+
+def _roi_moved(self, roi):
+    self.stateGroup.blockSignals(True)   # prevent loop
+    # update self.values and self.ctrls from roi geometry
+    self.stateGroup.blockSignals(False)
+    self.sigStateChanged.emit(self)      # triggers graph resubmit
+
+def update(self, *args, **kwargs):
+    super().update(*args, **kwargs)
+    if self.widget:
+        # sync ROI position when ctrl spinboxes change
+        self.roi.setPos(..., finish=False)
+        self.roi.setSize(..., finish=False)
+```
+
+See `ami/flowchart/library/Roi.py:237` (`Roi2D`) for a complete implementation.
+
+---
+
+## 6. Key Invariants and Gotchas
+
+1. **`nodeName` and docstring are mandatory.** `isNodeClass()` rejects classes without `nodeName`; `getLabelTree()` asserts a docstring. Always write both.
+
+2. **`global_op=True` whenever returning a `GlobalTransformation`.** Any node whose `to_operation()` returns `PickN`, `SumN`, `Accumulator`, `ReduceByKey`, or `RollingBuffer` (or a pipeline containing one) must set `global_op=True`. Forgetting this means the node renders without the blue color and the latch context menu — and more importantly the graph compiler may color it incorrectly.
+
+3. **Intermediate variable naming must be globally unique.** Convention: `self.name() + "_suffix"`. Since `self.name()` includes a unique instance number (e.g., `"FrameAverage.0"`), this is always unique across nodes. Never use a fixed string alone.
+
+4. **`SumN` and `RollingBuffer` always produce exactly 2 outputs:** `(count, sum)` and `(count, buffer)` respectively. The downstream `Map` must unpack both even if only one is needed.
+
+5. **`PickN` returns `None` until N samples are collected.** The downstream `Map` is only invoked when `PickN` fires (not on every event), so `None` is never passed to `Map` — but keep this in mind when reasoning about output cadence.
+
+6. **`gn.Accumulator` reduction signature:** `reduction(res, *values, count=count, reset=reset)`. The `reset` kwarg is `True` on the very first call after a heartbeat boundary (use it to initialize `res` cleanly rather than relying on `res_factory` alone). `count` is the number of events being folded in at this call.
+
+7. **`stateGroup.blockSignals(True/False)` when setting ctrl values programmatically.** Without blocking, `setValue()` triggers `sigChanged` → `state_changed()` → `update()` → potentially sets the widget again → infinite loop.
+
+8. **`buffered=True` and `viewable=True` are mutually exclusive in practice.** `viewable=True` means no `to_operation`; `buffered=True` means a `to_operation` that emits buffer variable names which the display subscribes to.
+
+9. **`isChanged()` must return truthy for `.fc` restore to trigger graph resubmit.** If your node's `to_operation()` depends on ctrl values (almost always true), return `restore_ctrl`. If it depends on widget state (code editor), return `restore_widget`. Viewer-only nodes return `False`.
+
+10. **Custom widget `close()` must call `self.fetcher.close()`.** `CtrlNode.close()` calls `self.widget.close()` automatically; if your widget doesn't close its `AsyncFetcher`, the ZMQ socket leaks.
+
+11. **Multi-input `Map` functions receive arguments in `inputs` dict order.** The function signature must match the number and order of inputs as they appear in the `inputs` dict passed to `to_operation()`.
+
+12. **Per-worker vs per-heartbeat execution.** `Map` and the `_worker` clone of `GlobalTransformation` nodes run on every raw event. The `_localCollector` and `_globalCollector` clones run once per heartbeat after all contributions arrive. Design your reduction functions accordingly — they are not called at event rate.
+
+---
+
+## 7. Registration via Manage Library
+
+Custom nodes do **not** need to be added to `ami/flowchart/library/__init__.py`. Use the Manage Library GUI instead:
+
+### Workflow
+
+1. **Write your node class** in a standalone `.py` file anywhere on disk. The file must contain at least one class that:
+   - Subclasses `Node` (or `CtrlNode`, `GroupedNode`, etc.)
+   - Has a `nodeName` class attribute
+   - Has a docstring
+
+2. **Open the flowchart GUI.** Click **"Manage Library"** in the toolbar (bottom of the flowchart canvas).
+
+3. Click **"Load Files"** (or "Load Directory" to scan a directory recursively) and select your `.py` file.
+
+4. Click **"Apply"** — `UnifiedLibraryEditor.applyClicked()` (`ami/flowchart/Editor.py:203`) calls `LIBRARY.addNodeType()` for each discovered class and refreshes the sidebar node tree.
+
+5. **Your node now appears in the sidebar** and can be dragged into the flowchart.
+
+### Persistence
+
+The loaded file paths are saved into the `.fc` flowchart file automatically (`state["library"]` at `Flowchart.py:1808`). When the `.fc` file is reopened, `restoreState()` + `applyClicked()` re-imports the modules and re-registers the nodes — no manual steps required.
+
+### Worker process propagation
+
+After Apply, `libraryUpdated()` (`Flowchart.py:2584`) sends `fcMsgs.Library` to the `MessageBroker`, which propagates the extra `sys.path` entries to all spawned node display subprocesses. Each `NodeProcess` re-imports the module and calls `LIBRARY.addNodeType()` on spawn (`ami/client/flowchart.py:245-257`).
+
+### Minimum viable `.py` file
+
+```python
+# my_nodes.py
+import ami.graph_nodes as gn
+from amitypes import Array1d
+from ami.flowchart.library.common import CtrlNode
+
+
+class MyCustomNode(CtrlNode):
+    """One-line description."""
+    nodeName = "MyCustomNode"
+    uiTemplate = [("N", "intSpin", {"value": 10, "min": 1})]
+
+    def __init__(self, name):
+        super().__init__(
+            name,
+            terminals={
+                "In":  {"io": "in",  "ttype": Array1d},
+                "Out": {"io": "out", "ttype": Array1d},
+            },
+        )
+
+    def to_operation(self, **kwargs):
+        n = self.values["N"]
+        return gn.Map(name=self.name() + "_operation", **kwargs, func=lambda a: a[:n])
+```
+
+Load this file via Manage Library → Load Files → Apply, and `MyCustomNode` will appear in the sidebar under its module name.
+
+---
+
+## 8. EPICS Ctrl Interface
+
+The flowchart automatically exposes every `uiTemplate` ctrl parameter of every node as a writable **PVAccess PV** via `ami/flowchart/PvCtrlServer.py`. This allows external tools (EPICS screens, scripts, other processes) to read and change graph parameters without touching the GUI.
+
+### PV naming
+
+```
+{prefix}:ctrl:{graph_name}:{NodeName.instance}:{param_name}
+{prefix}:ctrl:{graph_name}:apply
+```
+
+where `prefix = "{hutch}:ami"` when `--hutch` is passed to `ami-client`, otherwise `"ami"`.
+
+Grouped `uiTemplate` fields (those with a `"group"` key in opts) use `{group}__{param}` as the final component.
+
+**Examples** (hutch = `rix`, graph = `rix101331225`):
+```
+rix:ami:ctrl:rix101331225:FrameAverage.0:N         ← NTScalar int64, writable
+rix:ami:ctrl:rix101331225:Threshold1D.0:threshold  ← NTScalar float64, writable
+rix:ami:ctrl:rix101331225:Threshold1D.0:invert     ← NTScalar bool, writable
+rix:ami:ctrl:rix101331225:apply                    ← NTScalar bool, write to trigger Apply
+```
+
+### Workflow
+
+PV writes update the GUI widget and mark the node changed (Apply button turns green), **but do not immediately change the running graph**. This lets you batch multiple parameter changes:
+
+```bash
+# 1. Change parameters
+pvput rix:ami:ctrl:rix101331225:FrameAverage.0:N 50
+pvput rix:ami:ctrl:rix101331225:Threshold1D.0:threshold 0.5
+
+# 2. Apply all changes at once
+pvput rix:ami:ctrl:rix101331225:apply 1
+
+# Or via PVA RPC (returns immediately after scheduling apply)
+pvacall rix:ami:ctrl:rix101331225:apply
+```
+
+### Supported parameter types
+
+| `uiTemplate` type | EPICS NTScalar type | Notes |
+|---|---|---|
+| `intSpin` | `int64` | Clamped to `min`/`max` from uiTemplate |
+| `doubleSpin` / `spin` | `float64` | Clamped to `min`/`max` from uiTemplate |
+| `check` | `bool` | |
+| `combo` | `string` | Must match one of the combo items |
+| `text` | `string` | |
+| `file_in` / `file_out` / `color` | — | Not exposed (unsafe) |
+
+### Implementation
+
+`PvCtrlServer` (`ami/flowchart/PvCtrlServer.py`) is instantiated in `FlowchartCtrlWidget.__init__()` and requires `p4p` (already a dependency). It starts automatically — no configuration needed beyond `--hutch`.
+
+**For nodes you implement:** no changes are needed. Any node with a non-empty `uiTemplate` automatically gets EPICS PVs after the first Apply. Nodes with `uiTemplate = []` or no `uiTemplate` are silently skipped.


### PR DESCRIPTION
PvCtrlServer hosts writable PVs for every uiTemplate parameter of every parameterised node in the graph:

  {prefix}:ctrl:{graph_name}:{NodeName.N}:{param}   - write to update GUI
  {prefix}:ctrl:{graph_name}:apply                  - write any int to Apply

prefix is '{hutch}:ami' when --hutch is set, otherwise 'ami'.

Key design points:
- p4p asyncio SharedPV delivers PUT handlers via call_soon_threadsafe -> qasync Qt signal -> asyncio callback, so all handlers run in the Qt main thread and can call GUI APIs directly without a dispatcher.
- _update_gui calls stateGroup.setState (updates spinbox + node.values), emits sigNodeChanged (highlights Apply button), then fires a NodeCtrlUpdate ZMQ message to any open NodeProcess window.
- NodeCtrlUpdate is a new NodeMsg forwarded by MessageBroker to the NodeProcess, which applies setState with blockSignals so the visible spinbox updates without echoing a checkpoint back to the flowchart.
- apply PV is NTScalar('i') so 'pvput ... 1' works without quoting.