### PR TITLE
Fix subgraph connection crashes and add visual improvements

### DIFF
--- a/ami/flowchart/Editor.py
+++ b/ami/flowchart/Editor.py
@@ -424,13 +424,13 @@ class Ui_Toolbar(object):
             self.toolBar.insertSeparator(self.actionConfigure)
         else:
             self.toolBar.insertSeparator(self.actionApply)
-        # self.toolBar.addAction(self.actionArrange)
+        self.toolBar.addAction(self.actionArrange)
         self.toolBar.addAction(self.actionHome)
         self.toolBar.addAction(self.actionPan)
         self.toolBar.addAction(self.actionSelect)
         self.toolBar.addAction(self.actionComment)
         self.toolBar.addAction(self.actionInspector)
-        # self.toolBar.insertSeparator(self.actionArrange)
+        self.toolBar.insertSeparator(self.actionArrange)
         self.toolBar.insertSeparator(self.actionHome)
 
         widget = self.toolBar.widgetForAction(self.actionApply)

--- a/ami/flowchart/Flowchart.py
+++ b/ami/flowchart/Flowchart.py
@@ -210,6 +210,7 @@ class Flowchart(QtCore.QObject):
         node.sigTerminalRemoved.connect(self.nodeTermRemoved)
         node.sigLabelChanged.connect(self.nodeLabelChanged)
         node.setGraph(self._graph)
+        node._flowchart = self
 
         # if the node is a source, connect the source kwargs interface to the manager
         if node.isSource():
@@ -537,6 +538,10 @@ class Flowchart(QtCore.QObject):
             subgraphNode.subgraphOutputs.graphicsItem().moveBy(output_pos.x(), output_pos.y())
 
         # NOW process boundary connections - create visual-only connections
+        # Track which root-level visual connections have been made to avoid duplicates.
+        # A source terminal connecting to multiple internal nodes shares one placeholder terminal,
+        # so the root visual (external → placeholder) only needs to be created once.
+        root_visuals_created = {}  # terminal_name -> root_visual ConnectionItem
 
         for bc in boundary_connections:
             # Disconnect original connection (signal=False preserves _input_vars and graph edges)
@@ -560,8 +565,12 @@ class Flowchart(QtCore.QObject):
                     )
 
                 # Create visual connection in root view: external → placeholder
-                # connectTo registers in _connections, creates ConnectionItem, and recolors automatically
-                root_visual = bc["external_term"].connectTo(placeholder_term, signal=False, view=self.viewBox())
+                # Only create once per terminal_name (same source may feed multiple internal nodes)
+                if bc["terminal_name"] not in root_visuals_created:
+                    root_visual = bc["external_term"].connectTo(placeholder_term, signal=False, view=self.viewBox())
+                    root_visuals_created[bc["terminal_name"]] = root_visual
+                else:
+                    root_visual = root_visuals_created[bc["terminal_name"]]
 
                 # Create visual connection in subgraph view: subgraph_input → internal
                 sg_visual = sg_input_term.connectTo(bc["internal_term"], signal=False, view=view.viewBox())
@@ -580,11 +589,17 @@ class Flowchart(QtCore.QObject):
                     )
 
                 # Create visual connection in root view: placeholder → external
-                # connectTo registers in _connections, creates ConnectionItem, and recolors automatically
+                # Always create for each external node — placeholder is an output terminal
+                # and can fan out to multiple external inputs
                 root_visual = placeholder_term.connectTo(bc["external_term"], signal=False, view=self.viewBox())
 
                 # Create visual connection in subgraph view: internal → subgraph_output
-                sg_visual = bc["internal_term"].connectTo(sg_output_term, signal=False, view=view.viewBox())
+                # Only create once — same internal_term appears in multiple boundary_connections
+                # when its output fans out to multiple external nodes
+                if bc["internal_term"].connectedTo(sg_output_term):
+                    sg_visual = bc["internal_term"]._connections[sg_output_term]
+                else:
+                    sg_visual = bc["internal_term"].connectTo(sg_output_term, signal=False, view=view.viewBox())
 
             # Store visual connection references
             bc["root_visual"] = root_visual
@@ -846,9 +861,10 @@ class Flowchart(QtCore.QObject):
                 sg_output_term = subgraphNode.subgraphOutputs.terminals[bc["terminal_name"]]
 
                 # Create visual-only connection (now that nodes are in the view)
-                internal_term.connectTo(sg_output_term, signal=False)
-
-                # Get the ConnectionItem that was just created
+                # Guard against duplicates: same (internal_term, sg_output_term) pair may appear
+                # more than once if the internal output fans out to multiple external nodes
+                if not internal_term.connectedTo(sg_output_term):
+                    internal_term.connectTo(sg_output_term, signal=False)
                 conn_item = internal_term.connections().get(sg_output_term)
                 if conn_item:
                     bc["subgraph_visual"] = conn_item
@@ -1230,24 +1246,34 @@ class Flowchart(QtCore.QObject):
         boundary_inputs = []
         boundary_outputs = []
 
+        seen_input_terminals = set()
+        seen_output_terminals = set()
         for bc in sg_data.get("boundary_connections", []):
             if bc["type"] == "input":
-                term = placeholder.terminals.get(bc["terminal_name"])
+                term_name = bc["terminal_name"]
+                if term_name in seen_input_terminals:
+                    continue
+                seen_input_terminals.add(term_name)
+                term = placeholder.terminals.get(term_name)
                 if term:
                     boundary_inputs.append(
                         {
-                            "placeholder_terminal": bc["terminal_name"],
+                            "placeholder_terminal": term_name,
                             "internal_node": bc["internal_node"].name(),
                             "internal_terminal": bc["internal_term"].name(),
                             "ttype": term.type(),
                         }
                     )
             else:  # output
-                term = placeholder.terminals.get(bc["terminal_name"])
+                term_name = bc["terminal_name"]
+                if term_name in seen_output_terminals:
+                    continue
+                seen_output_terminals.add(term_name)
+                term = placeholder.terminals.get(term_name)
                 if term:
                     boundary_outputs.append(
                         {
-                            "placeholder_terminal": bc["terminal_name"],
+                            "placeholder_terminal": term_name,
                             "internal_node": bc["internal_node"].name(),
                             "internal_terminal": bc["internal_term"].name(),
                             "ttype": term.type(),
@@ -1838,7 +1864,21 @@ class Flowchart(QtCore.QObject):
         for from_node, to_node, data in self._graph.edges(data=True):
             from_term = data["from_term"]
             to_term = data["to_term"]
-            state["connects"].append((from_node, from_term, to_node, to_term))
+            color = None
+            try:
+                node1 = self._graph.nodes[from_node]["node"]
+                node2 = self._graph.nodes[to_node]["node"]
+                t1 = node1.terminals[from_term]
+                t2 = node2.terminals[to_term]
+                ci = t1._connections.get(t2) or t2._connections.get(t1)
+                if ci and getattr(ci, "_custom_color", None):
+                    color = list(ci._custom_color)
+            except (KeyError, AttributeError):
+                pass
+            entry = [from_node, from_term, to_node, to_term]
+            if color:
+                entry.append(color)
+            state["connects"].append(entry)
 
         # NEW: Save subgraphs (visual-only metadata)
         state["subgraphs"] = []
@@ -1920,14 +1960,16 @@ class Flowchart(QtCore.QObject):
 
             nodes = self.nodes(data="node")
 
-            for n1, t1, n2, t2 in state["connects"]:
+            for conn in state["connects"]:
+                n1, t1, n2, t2 = conn[0], conn[1], conn[2], conn[3]
+                color = conn[4] if len(conn) > 4 else None
                 try:
                     node1 = nodes[n1]
                     term1 = node1[t1]
                     node2 = nodes[n2]
                     term2 = node2[t2]
 
-                    term1.connectTo(term2, type_file=type_file, checked=checked)
+                    term1.connectTo(term2, type_file=type_file, checked=checked, color=color)
                     if term1.isInput():
                         in_name = node1.name() + "_" + term1.name()
                         in_name = in_name.replace(".", "_")
@@ -2548,24 +2590,77 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
         self.viewBox().autoRange(items=children)
 
     def arrangeClicked(self):
-        sources = []
-        displays = []
-        for name, data in self.chart._graph.nodes(data=True):
-            if data.get("subset") == 0:
-                sources.append(name)
-            elif data.get("subset") == 2:
-                displays.append(name)
-        fixed = sources + displays
-        pos = nx.drawing.layout.multipartite_layout(self.chart._graph, scale=len(self.chart._graph.nodes()) * 75)
-        pos = nx.drawing.layout.spring_layout(nx.Graph(self.chart._graph), pos=pos, fixed=fixed, k=200)
-        for name in self.chart._graph.nodes():
-            if name not in pos:
-                continue
-            px = pos[name][0]
-            py = pos[name][1]
-            p = (find_nearest(px), find_nearest(py))
-            node = self.chart._graph.nodes[name]["node"]
-            node.graphicsItem().setPos(*p)
+        """Auto-arrange nodes using topological layered layout."""
+        vm = self.viewManager()
+        sg_name = vm._currentSubgraphName
+
+        if sg_name and sg_name in self.chart._subgraphs:
+            # Subgraph view
+            sg_data = self.chart._subgraphs[sg_name]
+            node_names = set(sg_data["nodes"])
+            subgraph = self.chart._graph.subgraph(node_names)
+            placeholder = sg_data["placeholder"]
+        else:
+            # Root view: exclude nodes inside subgraphs
+            subgraph_nodes = set()
+            for sg_data in self.chart._subgraphs.values():
+                subgraph_nodes.update(sg_data["nodes"])
+            root_nodes = set(self.chart._graph.nodes()) - subgraph_nodes
+            subgraph = self.chart._graph.subgraph(root_nodes)
+            placeholder = None
+
+        if len(subgraph.nodes()) == 0:
+            return
+
+        # Assign layers via longest path (topological sort)
+        layers = {node: 0 for node in subgraph.nodes()}
+        try:
+            for node in nx.topological_sort(subgraph):
+                for successor in subgraph.successors(node):
+                    layers[successor] = max(layers[successor], layers[node] + 1)
+        except nx.NetworkXUnfeasible:
+            from collections import deque
+
+            sources = [n for n in subgraph.nodes() if subgraph.in_degree(n) == 0]
+            if not sources:
+                sources = list(subgraph.nodes())
+            visited = set()
+            queue = deque((s, 0) for s in sources)
+            while queue:
+                node, depth = queue.popleft()
+                if node in visited:
+                    layers[node] = max(layers[node], depth)
+                    continue
+                visited.add(node)
+                layers[node] = depth
+                for succ in subgraph.successors(node):
+                    queue.append((succ, depth + 1))
+
+        # Group by layer and position nodes
+        layer_groups = {}
+        for node, layer in layers.items():
+            layer_groups.setdefault(layer, []).append(node)
+
+        x_spacing = 300
+        y_spacing = 200
+        for layer_idx, nodes in sorted(layer_groups.items()):
+            x = layer_idx * x_spacing
+            y_offset = -(len(nodes) - 1) * y_spacing / 2
+            for i, node_name in enumerate(nodes):
+                y = y_offset + i * y_spacing
+                p = (find_nearest(x), find_nearest(y))
+                node = self.chart._graph.nodes[node_name]["node"]
+                node.graphicsItem().setPos(*p)
+
+        # Position visual boundary nodes for subgraph views
+        if placeholder:
+            max_layer = max(layer_groups.keys()) if layer_groups else 0
+            if hasattr(placeholder, "subgraphInputs") and placeholder.subgraphInputs.graphicsItem().scene():
+                placeholder.subgraphInputs.graphicsItem().setPos(find_nearest(-x_spacing), find_nearest(0))
+            if hasattr(placeholder, "subgraphOutputs") and placeholder.subgraphOutputs.graphicsItem().scene():
+                placeholder.subgraphOutputs.graphicsItem().setPos(
+                    find_nearest((max_layer + 1) * x_spacing), find_nearest(0)
+                )
 
         children = self.viewBox().allChildren()
         self.viewBox().autoRange(items=children)

--- a/ami/flowchart/Flowchart.py
+++ b/ami/flowchart/Flowchart.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, deque
 from datetime import datetime
 
 from pyqtgraph import FileDialog
@@ -1865,16 +1865,15 @@ class Flowchart(QtCore.QObject):
             from_term = data["from_term"]
             to_term = data["to_term"]
             color = None
-            try:
-                node1 = self._graph.nodes[from_node]["node"]
-                node2 = self._graph.nodes[to_node]["node"]
-                t1 = node1.terminals[from_term]
-                t2 = node2.terminals[to_term]
-                ci = t1._connections.get(t2) or t2._connections.get(t1)
-                if ci and getattr(ci, "_custom_color", None):
-                    color = list(ci._custom_color)
-            except (KeyError, AttributeError):
-                pass
+
+            node1 = self._graph.nodes[from_node]["node"]
+            node2 = self._graph.nodes[to_node]["node"]
+            t1 = node1.terminals[from_term]
+            t2 = node2.terminals[to_term]
+            ci = t1._connections.get(t2) or t2._connections.get(t1)
+            if ci and getattr(ci, "_custom_color", None):
+                color = list(ci._custom_color)
+
             entry = [from_node, from_term, to_node, to_term]
             if color:
                 entry.append(color)
@@ -2540,7 +2539,7 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
         state = self.chart.saveState()
         state = json.dumps(state, indent=2, separators=(",", ": "), sort_keys=False, cls=TypeEncoder)
 
-        ts = datetime.now().strftime("%d%m%Y_%H%M%S")
+        ts = datetime.now().strftime("%m%d%Y_%H%M%S")
         with open(os.path.expanduser(f"~/.cache/ami/autosave_{ts}.fc"), "w") as f:
             f.write(state)
             f.write("\n")
@@ -2619,8 +2618,6 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
                 for successor in subgraph.successors(node):
                     layers[successor] = max(layers[successor], layers[node] + 1)
         except nx.NetworkXUnfeasible:
-            from collections import deque
-
             sources = [n for n in subgraph.nodes() if subgraph.in_degree(n) == 0]
             if not sources:
                 sources = list(subgraph.nodes())

--- a/ami/flowchart/Node.py
+++ b/ami/flowchart/Node.py
@@ -878,6 +878,22 @@ class NodeGraphicsItem(GraphicsObject):
             return self.menu
 
         graph = self.node._graph
+
+        # Build extended node list including subgraph placeholders in the same view.
+        # SubgraphNode placeholders are visual-only and not in self._graph, so we
+        # find them via _flowchart._subgraphs, filtered to the current scene so that
+        # only placeholders visible in the same view are included.
+        node_items = list(graph.nodes(data="node"))
+        flowchart = getattr(self.node, "_flowchart", None)
+        if flowchart and hasattr(flowchart, "_subgraphs"):
+            my_scene = self.scene()
+            for sg_name, sg_data in flowchart._subgraphs.items():
+                placeholder = sg_data.get("placeholder")
+                if placeholder is None or placeholder is self.node:
+                    continue
+                if placeholder.graphicsItem().scene() is my_scene:
+                    node_items.append((sg_name, placeholder))
+
         self.connectTo = QtWidgets.QMenu("Connect To")
         self.connectToSubMenus = []
 
@@ -894,7 +910,7 @@ class NodeGraphicsItem(GraphicsObject):
                 term_menu = QtWidgets.QMenu(self.node.name() + "." + name)
                 add_term_menu = False
 
-                for node_name, node in graph.nodes(data="node"):
+                for node_name, node in node_items:
                     if node == self.node:
                         continue
 
@@ -922,7 +938,7 @@ class NodeGraphicsItem(GraphicsObject):
                 term_menu = QtWidgets.QMenu(self.node.name() + "." + name)
                 add_term_menu = False
 
-                for node_name, node in graph.nodes(data="node"):
+                for node_name, node in node_items:
                     if node == self.node:
                         continue
 

--- a/ami/flowchart/SubgraphNode.py
+++ b/ami/flowchart/SubgraphNode.py
@@ -122,6 +122,13 @@ class SubgraphNode(Node):
 
 class SubgraphNodeGraphicsItem(NodeGraphicsItem):
 
+    def __init__(self, node, brush=None):
+        if brush is None:
+            from pyqtgraph import functions as fn
+
+            brush = fn.mkBrush(120, 80, 200, 220)
+        super().__init__(node, brush=brush)
+
     def mouseDoubleClickEvent(self, ev):
         """Switch to subgraph view on double-click"""
         ev.accept()

--- a/ami/flowchart/SubgraphNode.py
+++ b/ami/flowchart/SubgraphNode.py
@@ -1,3 +1,4 @@
+from pyqtgraph import functions as fn
 from pyqtgraph.Qt import QtWidgets
 
 from ami.flowchart.Node import Node, NodeGraphicsItem
@@ -124,8 +125,6 @@ class SubgraphNodeGraphicsItem(NodeGraphicsItem):
 
     def __init__(self, node, brush=None):
         if brush is None:
-            from pyqtgraph import functions as fn
-
             brush = fn.mkBrush(120, 80, 200, 220)
         super().__init__(node, brush=brush)
 

--- a/ami/flowchart/Terminal.py
+++ b/ami/flowchart/Terminal.py
@@ -14,6 +14,8 @@ from pyqtgraph.graphicsItems.GraphicsObject import GraphicsObject
 from pyqtgraph.Point import Point
 from qtpy import QtCore, QtGui, QtWidgets
 
+from ami.flowchart.library.Editors import STYLE
+
 # Terminal label truncation configuration
 LABEL_WIDTH_RATIO = 0.45  # 45% of node width per side
 MIN_LABEL_WIDTH = 30  # Minimum for readability (px)
@@ -43,8 +45,6 @@ def _hash_hue(key):
 
 
 def _assign_connection_color(conn_item, term1, term2):
-    from ami.flowchart.library.Editors import STYLE
-
     conn_style = STYLE.get("Connections", {})
     mode = conn_style.get("color_mode", "default")
     if mode == "default":

--- a/ami/flowchart/Terminal.py
+++ b/ami/flowchart/Terminal.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import colorsys
+import hashlib
 import inspect
 import os
+import random
 import subprocess
 import tempfile
 import typing
@@ -16,6 +19,50 @@ LABEL_WIDTH_RATIO = 0.45  # 45% of node width per side
 MIN_LABEL_WIDTH = 30  # Minimum for readability (px)
 MAX_LABEL_WIDTH = 100  # Maximum even on huge nodes (px)
 TERMINAL_BOX_WIDTH = 10  # Terminal box width (px)
+
+
+_DEFAULT_PALETTE = [
+    (230, 100, 100),
+    (100, 200, 100),
+    (100, 140, 255),
+    (240, 190, 60),
+    (200, 100, 220),
+    (50, 210, 210),
+    (255, 150, 60),
+    (160, 230, 160),
+]
+
+
+def _hsv_color(h, s=0.85, v=0.88):
+    r, g, b = colorsys.hsv_to_rgb(h, s, v)
+    return (int(r * 255), int(g * 255), int(b * 255), 255)
+
+
+def _hash_hue(key):
+    return int(hashlib.md5(key.encode()).hexdigest()[:8], 16) / 0xFFFFFFFF
+
+
+def _assign_connection_color(conn_item, term1, term2):
+    from ami.flowchart.library.Editors import STYLE
+
+    conn_style = STYLE.get("Connections", {})
+    mode = conn_style.get("color_mode", "default")
+    if mode == "default":
+        return
+    out_term = term1 if term1.isOutput() else term2
+    key = f"{out_term.node().name()}.{out_term.name()}"
+    if mode == "random":
+        color = _hsv_color(random.random())
+    elif mode == "per_source":
+        color = _hsv_color(_hash_hue(key))
+    elif mode == "palette":
+        palette = conn_style.get("palette", _DEFAULT_PALETTE)
+        idx = int(_hash_hue(key) * len(palette)) % len(palette)
+        c = palette[idx]
+        color = (c[0], c[1], c[2], c[3] if len(c) > 3 else 255)
+    else:
+        return
+    conn_item.setCustomColor(color)
 
 
 class Terminal(QtCore.QObject):
@@ -145,7 +192,7 @@ class Terminal(QtCore.QObject):
         """Return the list of terms which receive input from this terminal."""
         return set([t for t in self.connections() if t.isInput()])
 
-    def connectTo(self, term, connectionItem=None, type_file=None, checked=[], signal=True, view=None):
+    def connectTo(self, term, connectionItem=None, type_file=None, checked=[], signal=True, view=None, color=None):
         try:
             if self.connectedTo(term):
                 raise Exception("Already connected")
@@ -187,6 +234,10 @@ class Terminal(QtCore.QObject):
                 view.addItem(connectionItem)
             else:
                 self.graphicsItem().getViewBox().addItem(connectionItem)
+            if color is not None:
+                connectionItem.setCustomColor(color)
+            elif signal:
+                _assign_connection_color(connectionItem, self, term)
         self._connections[term] = connectionItem
         term._connections[self] = connectionItem
 
@@ -580,6 +631,7 @@ class ConnectionItem(GraphicsObject):
             "selectedColor": (200, 200, 0),
             "selectedWidth": 3.0,
         }
+        self._custom_color = None
         self.source.getViewBox().addItem(self)
         self.updateLine()
         self.setZValue(0)
@@ -598,6 +650,10 @@ class ConnectionItem(GraphicsObject):
             self.updateLine()
         else:
             self.update()
+
+    def setCustomColor(self, color):
+        self._custom_color = color
+        self.update()
 
     def updateLine(self):
         start = Point(self.source.connectPoint())
@@ -678,7 +734,8 @@ class ConnectionItem(GraphicsObject):
             if self.hovered:
                 p.setPen(fn.mkPen(self.style["hoverColor"], width=self.style["hoverWidth"]))
             else:
-                p.setPen(fn.mkPen(self.style["color"], width=self.style["width"]))
+                color = self._custom_color if self._custom_color else self.style["color"]
+                p.setPen(fn.mkPen(color, width=self.style["width"]))
 
         p.drawPath(self.path)
 

--- a/examples/stylesheet.json
+++ b/examples/stylesheet.json
@@ -1,7 +1,7 @@
 {
     "FontSize": 12,
     "Connections": {
-        "color_mode": "default"
+        "color_mode": "per_source"
     },
     "SourceTree":
     {

--- a/examples/stylesheet.json
+++ b/examples/stylesheet.json
@@ -1,5 +1,8 @@
 {
     "FontSize": 12,
+    "Connections": {
+        "color_mode": "default"
+    },
     "SourceTree":
     {
         "expand" : false

--- a/examples/stylesheet_dark.json
+++ b/examples/stylesheet_dark.json
@@ -2,6 +2,9 @@
     "Theme": "dark",
     "FontSize": 12,
     "Background": [32, 33, 36],
+    "Connections": {
+        "color_mode": "default"
+    },
     "WaveformWidget":
     {
         "Point": {


### PR DESCRIPTION
Bug fixes:
- Fix 'Already connected' crash in makeSubgraphFromSelection when an internal node's output fans out to multiple external nodes
- Fix same crash when instantiating a subgraph from the library (_addSubgraphToLibrary now deduplicates boundary entries by terminal name; _createSubgraphFromImport guards connectTo with connectedTo check)
- Fix root nodes becoming visually disconnected after subgraph creation (output placeholder terminal can fan out, so drop the wrong-sided root_visuals_created deduplication for the output case)
- Fix SubgraphNode placeholders missing from the 'Connect To' context menu (set _flowchart on all nodes in addNode; getMenu includes placeholders from the same scene via _flowchart._subgraphs)

Visual improvements:
- Replace spring-layout auto-arrange with a view-aware topological layered layout (longest-path DAG, BFS fallback for cycles); positions SubgraphInputs/Outputs helpers at far-left/far-right in subgraph views
- Re-enable the Arrange toolbar button
- Add connection color modes via stylesheet 'Connections.color_mode': 'random' (per-connection, persisted), 'per_source' (hash of source terminal, deterministic), 'palette' (hash into a color list)
- SubgraphNode placeholders now render purple to distinguish them from regular nodes