### PR TITLE
Add Reset on Run checkbox to global op and buffered display nodes

### DIFF
--- a/ami/flowchart/Flowchart.py
+++ b/ami/flowchart/Flowchart.py
@@ -205,6 +205,7 @@ class Flowchart(QtCore.QObject):
         node.sigTerminalDisconnected.connect(self.nodeTermDisconnected)
         node.sigNodeEnabled.connect(self.nodeEnabled)
         node.sigNodeLatched.connect(self.nodeLatched)
+        node.sigNodeResetOnRun.connect(self.nodeResetOnRun)
         node.sigTerminalOptional.connect(self.nodeTermOptional)
         node.sigTerminalAdded.connect(self.nodeTermAdded)
         node.sigTerminalRemoved.connect(self.nodeTermRemoved)
@@ -1756,6 +1757,10 @@ class Flowchart(QtCore.QObject):
         node.changed = True
         self.sigNodeChanged.emit(node)
 
+    def nodeResetOnRun(self, node):
+        node.changed = True
+        self.sigNodeChanged.emit(node)
+
     @asyncSlot(object, object)
     async def nodeLabelChanged(self, node, label):
         """Handle label change events from nodes and forward to NodeProcess"""
@@ -2490,6 +2495,7 @@ class FlowchartCtrlWidget(QtWidgets.QWidget):
                                 outputs=node.output_vars(),
                                 parent=node.name(),
                                 latched=node.latched,
+                                reset_on_run=node.reset_on_run,
                             )
                         except Exception as e:
                             self.chartWidget.updateStatus(f"{node.name()} {e}!", color="red")

--- a/ami/flowchart/Node.py
+++ b/ami/flowchart/Node.py
@@ -91,6 +91,7 @@ class Node(QtCore.QObject):
     sigTerminalOptional = QtCore.Signal(object, object)  # self, term
     sigNodeEnabled = QtCore.Signal(object)  # self
     sigNodeLatched = QtCore.Signal(object)  # self
+    sigNodeResetOnRun = QtCore.Signal(object)  # self
     sigLabelChanged = QtCore.Signal(object, object)  # self, label
 
     def __init__(self, name, **kwargs):
@@ -154,6 +155,7 @@ class Node(QtCore.QObject):
 
         self.global_op = kwargs.get("global_op", False)
         self.latched = False
+        self.reset_on_run = True
 
         self._input_vars = {}  # term:var
 
@@ -222,6 +224,14 @@ class Node(QtCore.QObject):
         self.graphicsItem().latch.blockSignals(True)
         self.graphicsItem().latch.setChecked(latched)
         self.graphicsItem().latch.blockSignals(False)
+
+    def nodeResetOnRun(self, reset_on_run):
+        self.reset_on_run = reset_on_run
+
+        # block signals to avoid recursive calls
+        self.graphicsItem().reset_on_run_action.blockSignals(True)
+        self.graphicsItem().reset_on_run_action.setChecked(reset_on_run)
+        self.graphicsItem().reset_on_run_action.blockSignals(False)
 
     def addInput(self, name="In", **kwargs):
         """Add a new input terminal to this Node with the given name. Extra
@@ -510,6 +520,7 @@ class Node(QtCore.QObject):
             "enabled": self._enabled,
             "viewed": self.viewed,
             "latched": self.latched,
+            "reset_on_run": self.reset_on_run,
             "label": self._label,
         }
         state["terminals"] = self.saveTerminals()
@@ -524,6 +535,7 @@ class Node(QtCore.QObject):
         self._enabled = state.get("enabled")
         self.viewed = state.get("viewed", False)
         self.nodeLatched(state.get("latched", False))
+        self.nodeResetOnRun(state.get("reset_on_run", True))
         if self._label:
             self.graphicsItem().setLabel(self._label)
         if "terminals" in state:
@@ -667,6 +679,7 @@ class NodeGraphicsItem(GraphicsObject):
         self.enabled = QtWidgets.QAction("Enabled", self.menu, checkable=True, checked=True)
         self.optional = QtWidgets.QAction("Optional Inputs", self.menu, checkable=True, checked=False)
         self.latch = QtWidgets.QAction("Latch Outputs", self.menu, checkable=True, checked=False)
+        self.reset_on_run_action = QtWidgets.QAction("Reset on Run", self.menu, checkable=True, checked=True)
         self.buildMenu()
 
     def setPen(self, *args, **kwargs):
@@ -1002,6 +1015,9 @@ class NodeGraphicsItem(GraphicsObject):
             if self.node.global_op:
                 self.latch.toggled.connect(self.latchedFromMenu)
                 self.menu.addAction(self.latch)
+            if self.node.global_op or self.node._buffered:
+                self.reset_on_run_action.toggled.connect(self.resetOnRunFromMenu)
+                self.menu.addAction(self.reset_on_run_action)
             if self.node._allowAddInput:
                 self.menu.addAction("Add input", self.addInputFromMenu)
             if self.node._allowAddOutput:
@@ -1028,6 +1044,10 @@ class NodeGraphicsItem(GraphicsObject):
     def latchedFromMenu(self, checked):
         self.node.nodeLatched(checked)
         self.node.sigNodeLatched.emit(self.node)
+
+    def resetOnRunFromMenu(self, checked):
+        self.node.nodeResetOnRun(checked)
+        self.node.sigNodeResetOnRun.emit(self.node)
 
     def addInputFromMenu(self):
         # called when add input is clicked in context menu

--- a/ami/graph_nodes.py
+++ b/ami/graph_nodes.py
@@ -117,6 +117,7 @@ class StatefulTransformation(Transformation):
         local_reduction = kwargs.pop("local_reduction", None)
         global_reduction = kwargs.pop("global_reduction", None)
         latched = kwargs.pop("latched", False)
+        reset_on_run = kwargs.pop("reset_on_run", True)
 
         kwargs.setdefault("func", None)
         super().__init__(**kwargs)
@@ -135,6 +136,7 @@ class StatefulTransformation(Transformation):
         self._local_reduction = local_reduction
         self._global_reduction = global_reduction
         self.latched = latched
+        self.reset_on_run = reset_on_run
 
     @abc.abstractmethod
     def __call__(self, *args, **kwargs):
@@ -201,7 +203,7 @@ class GlobalTransformation(StatefulTransformation):
             Dictionary of keyword arguments to pass when constructing the
             globally expanded version of this operation
         """
-        return {"parent": self.parent, "latched": self.latched}
+        return {"parent": self.parent, "latched": self.latched, "reset_on_run": self.reset_on_run}
 
 
 class ReduceByKey(GlobalTransformation):

--- a/ami/graphkit_wrapper.py
+++ b/ami/graphkit_wrapper.py
@@ -232,7 +232,8 @@ class Graph:
 
     def reset(self):
         """
-        Resets the state of all StatefulTransmation nodes in the graph.
+        Resets the state of all StatefulTransmation nodes in the graph that
+        have reset_on_run enabled (default True).
         """
         nodes = list(
             filter(
@@ -240,7 +241,9 @@ class Graph:
                 self.graph.nodes,
             )
         )
-        list(map(lambda node: node.reset(), nodes))
+        for node in nodes:
+            if getattr(node, "reset_on_run", True):
+                node.reset()
         self.latch_cache = {}
 
     def heartbeat_finished(self):


### PR DESCRIPTION
- Add reset_on_run bool (default True) to Node base class with save/restore, signal, and nodeResetOnRun() method mirroring latch
- Add Reset on Run QAction to right-click menu for global_op and _buffered nodes (PickN, SumN, Accumulator, RollingBuffer, ScatterPlot, ScalarPlot, TimePlot, etc.)
- Pass reset_on_run through to_operation() kwargs into StatefulTransformation.__init__ and propagate via on_expand() so all three expansion tiers carry the flag
- Graph.reset() skips nodes where reset_on_run=False, preserving accumulated state across run boundaries when unchecked